### PR TITLE
docs(skills): compress 8 skills — move body content to references/

### DIFF
--- a/.github/agents/code-quality-reviewer.md
+++ b/.github/agents/code-quality-reviewer.md
@@ -63,6 +63,7 @@ Do not ask the caller to provide a diff. Derive it yourself.
 - [ ] Deprecated symbols: all call sites removed or annotated
 - [ ] Public interface changed → documentation updated in same commit
 - [ ] Broken windows noted (not silently walked past)
+- [ ] No reference file contains a pointer that refers back to itself (self-referential pointer). A fix that changes a broken pointer to a self-reference is still a bug — flag as critical regardless of whether the reviewer can construct a justification for why it looks intentional.
 
 ### Architecture
 - [ ] No direct OpenGL calls outside `IOpenGLContext` implementations

--- a/.github/agents/implementer.md
+++ b/.github/agents/implementer.md
@@ -89,11 +89,29 @@ auto calculateTotal(std::vector<Item> items) -> int {
 
 Before committing: grep every fenced code block for `std::`, `nullptr`, `#include`, `TEST(`, `ASSERT_`, `EXPECT_`, `glm::`. Any hit is a violation.
 
+## Skill Content Moves — Verbatim Gate
+
+When moving content FROM a source file TO a target file (e.g., SKILL.md → references/):
+
+1. **Write the content into the target file first.**
+2. **Verify the paste is character-for-character identical** — use `diff` or `grep` to confirm. Do not rely on visual inspection.
+3. **Only then remove the content from the source file.**
+
+Removing content from the source without a verified paste in the target is a spec violation. There is no exception for "obviously identical" content.
+
 ## Verification gate before marking done
 1. `cmake --build build` — must succeed
 2. `./build/tests/ParticleViewerTests` — all tests green
 3. `find src tests -name "*.cpp" -o -name "*.hpp" | xargs clang-format -i` — format clean
 4. `git diff HEAD~1` — diff reviewed, no accidental changes
+
+## Fix Agent Rules
+
+When acting as a fix agent (correcting issues flagged by a Stage 1 or Stage 2 reviewer):
+
+**Surrounding context:** After applying the fix, read the 5 lines above and 5 lines below the changed region. If adjacent content was affected (broken numbering, orphaned pointer, new redundancy), fix that too before committing.
+
+**Reviewer verdicts are binding:** If a Stage 1 or Stage 2 reviewer flagged an issue, fix it. Do not evaluate whether the fix is "needed." The reviewer's verdict is binding. Only escalate — do not silently override — if the fix would violate a hard rule stated in the task prompt.
 
 ## Return format
 ```

--- a/.github/skills/code-quality/SKILL.md
+++ b/.github/skills/code-quality/SKILL.md
@@ -12,7 +12,15 @@ NO UNFORMATTED OR UNTIDY CODE SHIPS
 
 YOU MUST run clang-format AND clang-tidy BEFORE every commit. CI will reject violations. No exceptions.
 
+Violating the letter of this rule is violating the spirit of this rule.
+
 **Announce at start:** "I am using the code-quality skill to [format/lint/review] [description]."
+
+---
+
+## Core Principle: Tools Enforce Style, Humans Write Logic
+
+Formatting and naming are automated via `.clang-format` and `.clang-tidy`. Never manually format code — run the tools.
 
 ---
 
@@ -22,6 +30,10 @@ Run before **every** commit:
 
 ```bash
 find src tests -name "*.cpp" -o -name "*.hpp" | xargs clang-format -i
+
+# 2. Check what changed
+git diff --name-only | head -20
+
 git diff src/[touched_file].cpp | head -100
 find src tests -name "*.cpp" -o -name "*.hpp" | xargs clang-format --dry-run -Werror
 cmake --build build && ./build/tests/ParticleViewerTests

--- a/.github/skills/code-quality/SKILL.md
+++ b/.github/skills/code-quality/SKILL.md
@@ -12,189 +12,44 @@ NO UNFORMATTED OR UNTIDY CODE SHIPS
 
 YOU MUST run clang-format AND clang-tidy BEFORE every commit. CI will reject violations. No exceptions.
 
-Violating the letter of this rule is violating the spirit of this rule.
-
 **Announce at start:** "I am using the code-quality skill to [format/lint/review] [description]."
 
 ---
 
-# Instructions for Agent
+## Pre-Commit Gate (MANDATORY)
 
-## How This Skill is Invoked
-
-In VS Code, users will activate this skill by:
-- Typing `@workspace /code-quality [description]` in Copilot Chat
-- Or asking: "Format the code", "Fix clang-tidy warnings", "What naming convention?", "Pre-commit checklist"
-
-When activated, apply the formatting, naming, and pattern rules below.
-
----
-
-## Core Principle: Tools Enforce Style, Humans Write Logic
-
-Formatting and naming are automated via `.clang-format` and `.clang-tidy`. Never manually format code — run the tools.
-
----
-
-## Step 1: Pre-Commit Checklist (MANDATORY)
-
-Run these before **every** commit:
+Run before **every** commit:
 
 ```bash
-# 1. Format ALL changed C++ files
 find src tests -name "*.cpp" -o -name "*.hpp" | xargs clang-format -i
-
-# 2. Check what changed
-git diff --name-only | head -20
-
-# 3. Spot-check any files you touched (don't trust silent tool output)
-# Look for: trailing semicolons after function }, exception handling, 
-# multi-declaration statements, bracing consistency
 git diff src/[touched_file].cpp | head -100
-
-# 4. Verify formatting passes (same check CI runs)
 find src tests -name "*.cpp" -o -name "*.hpp" | xargs clang-format --dry-run -Werror
-
-# 5. Build and test
-cmake --build build
-./build/tests/ParticleViewerTests
-
-# 6. (Optional) Static analysis
-clang-tidy src/main.cpp -- -Isrc/glad/include
+cmake --build build && ./build/tests/ParticleViewerTests
+clang-tidy src/main.cpp -- -Isrc/glad/include  # optional
 ```
 
 **⚠️ Critical:** Do NOT trust that `clang-format --dry-run -Werror` with no output means success. Always visually inspect `git diff` of modified files. Silent tool output can mask formatting issues.
 
 ---
 
-## Step 2: Formatting Rules (clang-format)
+## Naming Conventions (clang-tidy enforced)
 
-For clang-format settings (indentation, line length, brace style, include order, pointer alignment) and `.clang-format` reference, see `references/CPP_TOOLCHAIN.md`.
-
----
-
-## Step 3: Human-Reviewable Formatting Patterns
-
-These require **manual inspection** after running clang-format — tools don't always catch them:
-
-| Issue | Fix | Example |
-|-------|-----|---------|
-| Semicolon after function closing brace | Remove trailing `;` | `void foo() { }` not `void foo() { };` |
-| Empty constructor syntax | Use `= default` | `Shader() = default;` not `Shader() {};` |
-| Exception catching by value | Catch by const reference | `catch (const std::ifstream::failure& e)` |
-| Multiple declarations in one line | Split to separate lines | `uint32_t w; uint32_t h;` not `uint32_t w, h;` |
-
-**Always check `git diff` for these patterns after formatting.**
-
----
-
-## Step 4: Naming Conventions (clang-tidy enforced)
-
-| Element | Convention | Example |
-|---------|-----------|---------|
-| Classes/Structs/Enums | `PascalCase` | `ParticleSystem`, `RenderSettings` |
-| Functions/Methods | `camelCase` (USE camelCase; not enforced by clang-tidy) | `initializeBuffers`, `getParticleCount` |
-| Variables/Parameters | `snake_case` | `particle_count`, `delta_time` |
-| Member variables | `snake_case` + trailing `_` for private | `window_width`, `camera_` |
-| Constants/Macros | `UPPER_CASE` | `MAX_PARTICLES`, `PI` |
-| File names | `snake_case` | `particle_system.hpp` |
-| Include guards | `<PROJECT>_<PATH>_<FILE>_H` | `PARTICLE_VIEWER_PARTICLE_SYSTEM_H` |
-| Namespaces | `snake_case` | `particle_viewer` |
-
----
-
-## Step 5: Static Analysis (clang-tidy)
-
-For clang-tidy commands, enabled checks, configuration details, and CI status, see `references/CPP_TOOLCHAIN.md`.
-
----
-
-## Step 6: Project-Specific C++ Patterns
-
-For runtime patterns (data organization, error handling, memory management, OpenGL/SDL3 usage, DRY, Broken Window Protocol, Deprecation, Docs-Same-Commit), load the `cpp-patterns` skill (`.github/skills/cpp-patterns/`).
-
----
-
-## Step 7: Adding a Feature / Fixing a Bug
-
-### New Feature Workflow
-1. **Scan the class interface** — before writing integration code that calls methods on an existing class, verify which members are public/private. Classes like `Camera` have a mix; don't assume public.
-2. Make code changes following naming conventions
-3. Add unit tests in `tests/core/` (see `testing` skill)
-4. Run `clang-format -i` on ALL changed files
-5. Build and verify tests pass
-6. Commit: `feat: description`
-
-### Removing Features / User-Requested Changes
-When removing a gamepad feature or call site from `viewer_app.cpp` at user request, **do not also delete the supporting `Camera` public method**. The Camera API is stable across sessions; call sites in `viewer_app` change frequently with user preferences. Removing `isRenderingSphere()` when L3/R3 was dropped meant restoring it when L3/R3 came back one session later. Only remove a Camera method if it is architecturally wrong, not merely unused at the current moment.
-
-### Bug Fix Workflow
-1. Write a failing test that reproduces the bug
-2. Fix the code
-3. Verify test passes, run full suite
-4. Run `clang-format -i` on changed files
-5. Commit: `fix: description`
+`PascalCase` classes/enums · `camelCase` methods · `snake_case` vars/params · `snake_case_` private members · `UPPER_CASE` constants · `snake_case` files/namespaces · `<PROJECT>_<PATH>_<FILE>_H` guards
 
 ---
 
 ## Code Smell Review Checklist
 
-Static analysis catches syntax violations. These structural smells require human review on every PR:
+- **DuplicatedCode** — Same logic block in 2+ places? Extract it.
+- **LongMethod** — Method longer than ~30 lines? Apply ExtractMethod.
+- **GodClass** — One class controlling too many subsystems? Split responsibilities.
+- **DataClumps** — Same 2+ variables always travelling together? Introduce a struct.
+- **PrimitiveObsession** — Domain concepts as raw `int`, `float`, or `GLenum`? Introduce typed wrappers.
 
-| Smell | What to Look For |
-|---|---|
-| **DuplicatedCode** | Same logic block in 2+ places? Extract it. |
-| **LongMethod** | Method longer than ~30 lines? Apply ExtractMethod. |
-| **GodClass** | One class controlling too many subsystems? Split responsibilities. |
-| **DataClumps** | Same 2+ variables always travelling together? Introduce a struct. |
-| **PrimitiveObsession** | Domain concepts as raw `int`, `float`, or `GLenum`? Introduce typed wrappers. |
-| **FeatureEnvy** | Method references another class's data more than its own? Apply MoveMethod. |
-| **MagicNumber** | Literals in GL calls or formulas? Name them as constants. |
-| **ArrowAntiPattern** | More than 3 levels of nesting? Introduce guard clauses or RAII. |
-| **SpeculativeGenerality** | Abstraction with exactly one implementation? Remove it until a second arrives. |
-| **CommentSubstitutingForCode** | Comment explains WHAT the code does (not WHY)? Rename or refactor instead. |
+See `references/CODE_SMELLS.md` for the full checklist.
 
 ✓ All checked → no structural smells found
 ✗ Any flagged → log `[BROKEN WINDOW NOTED]` or fix before commit (see `cpp-patterns` skill)
-
----
-
-## Code Duplication: Once And Only Once vs Don't Repeat Yourself
-
-These two principles are frequently conflated but target different problems:
-
-| Principle | Source | What it targets | How to fix |
-|-----------|--------|-----------------|------------|
-| **Once And Only Once** | Ward Cunningham / Extreme Programming | The same *code logic* appears in two or more places | Refactor: extract a method, function, or class |
-| **Don't Repeat Yourself** | Hunt & Thomas, *The Pragmatic Programmer* | The same *knowledge or fact* is encoded in two or more places, even if the code looks different | Introduce a single authoritative source of truth |
-
-**Key distinction:** Two code blocks can look identical yet not violate Don't Repeat Yourself if they represent two independent domain concepts that happen to look similar today. Merging them creates false coupling. Conversely, two code blocks can look completely different yet violate Don't Repeat Yourself if they both encode the same business rule.
-
-| Situation | Principle violated | Correct action |
-|-----------|-------------------|----------------|
-| Same validation logic repeated in three `if` blocks | Once And Only Once | Extract a `validate()` function |
-| Maximum buffer size duplicated as a constant and a comment | Don't Repeat Yourself | Remove the comment; the constant is the source of truth |
-| Two classes share a 3-line helper computing screen coordinates | Once And Only Once | Extract to a shared utility |
-| Database schema and response struct both define "a user has email and name" | Don't Repeat Yourself | Generate one from the other, or treat one as the source of truth |
-| Two unrelated features happen to iterate in the same way | Neither | Leave them separate; forced unification creates accidental coupling |
-
----
-
-## Review Checklist
-
-- [ ] `clang-format -i` run on all changed files
-- [ ] `clang-format --dry-run -Werror` passes
-- [ ] Build succeeds
-- [ ] All tests pass
-- [ ] Conventional commit message format used
-- [ ] No raw `new`/`delete` — use RAII or smart pointers
-- [ ] GL resources cleaned up in destructors
-- [ ] Headers are self-contained
-- [ ] If a public interface changed: documentation updated in same commit (see cpp-patterns skill)
-- [ ] If a symbol is deprecated: all call sites removed or annotated (see cpp-patterns skill)
-
-✓ All 10 met → proceed to commit
-✗ Any unmet → complete the failing step before committing
 
 ---
 
@@ -228,9 +83,12 @@ If you catch yourself thinking any of these, stop and follow the rule:
 ## Reference
 
 - Full coding standards: [`docs/CODING_STANDARDS.md`](../../../docs/CODING_STANDARDS.md)
-- clang-format config: `.clang-format`
-- clang-tidy config: `.clang-tidy`
-- Commit format: `versioning` skill (`.github/skills/versioning/`)
-- Testing patterns: `testing` skill (`.github/skills/testing/`)
-- Design principles: `references/DESIGN_PRINCIPLES.md` — Kent Beck's 4 rules, essential vs accidental complexity, actionable error messages
-- Code smells: `references/CODE_SMELLS.md` — Fowler's 18 canonical code smells, detection heuristics, refactoring map
+- Commit format: `versioning` skill
+- Testing patterns: `testing` skill
+- `references/CPP_TOOLCHAIN.md` — formatting settings, clang-tidy, PV workflow patterns
+- `references/FORMATTING_RULES.md` — human-reviewable formatting patterns
+- `cpp-patterns` skill — C++ runtime patterns
+- `references/DESIGN_PRINCIPLES.md` — design heuristics
+- `references/CODE_SMELLS.md` — smells, refactoring map
+- `references/NAMING_TABLES.md` — naming examples
+- `references/REVIEW_CHECKLIST.md` — pre-review checklist

--- a/.github/skills/code-quality/SKILL.md
+++ b/.github/skills/code-quality/SKILL.md
@@ -61,6 +61,8 @@ See `references/FORMATTING_RULES.md` for formatting rule details.
 
 `PascalCase` classes/enums · `camelCase` methods · `snake_case` vars/params · `snake_case_` private members · `UPPER_CASE` constants · `snake_case` files/namespaces · `<PROJECT>_<PATH>_<FILE>_H` guards
 
+See `references/NAMING_TABLES.md` for full naming examples.
+
 ---
 
 ## Adding a Feature / Fixing a Bug
@@ -79,12 +81,10 @@ Static analysis catches syntax violations. These structural smells require human
 - **DataClumps** — Same 2+ variables always travelling together? Introduce a struct.
 - **PrimitiveObsession** — Domain concepts as raw `int`, `float`, or `GLenum`? Introduce typed wrappers.
 
-See `references/CODE_SMELLS.md` for the full checklist.
+See `references/CODE_SMELLS.md` for the full code smells catalog.
 
 ✓ All checked → no structural smells found
 ✗ Any flagged → log `[BROKEN WINDOW NOTED]` or fix before commit (see `cpp-patterns` skill)
-
-See `references/CODE_SMELLS.md` for the full code smells catalog.
 
 ---
 
@@ -136,3 +136,4 @@ If you catch yourself thinking any of these, stop and follow the rule:
 - `references/CODE_SMELLS.md` — smells, refactoring map
 - `references/NAMING_TABLES.md` — naming examples
 - `references/REVIEW_CHECKLIST.md` — pre-review checklist
+- `references/INVOCATION.md` — agent invocation instructions

--- a/.github/skills/code-quality/SKILL.md
+++ b/.github/skills/code-quality/SKILL.md
@@ -29,18 +29,31 @@ Formatting and naming are automated via `.clang-format` and `.clang-tidy`. Never
 Run before **every** commit:
 
 ```bash
+# 1. Format ALL changed C++ files
 find src tests -name "*.cpp" -o -name "*.hpp" | xargs clang-format -i
 
 # 2. Check what changed
 git diff --name-only | head -20
 
+# 3. Spot-check any files you touched (don't trust silent tool output)
+# Look for: trailing semicolons after function }, exception handling,
+# multi-declaration statements, bracing consistency
 git diff src/[touched_file].cpp | head -100
+
+# 4. Verify formatting passes (same check CI runs)
 find src tests -name "*.cpp" -o -name "*.hpp" | xargs clang-format --dry-run -Werror
-cmake --build build && ./build/tests/ParticleViewerTests
-clang-tidy src/main.cpp -- -Isrc/glad/include  # optional
+
+# 5. Build and test
+cmake --build build
+./build/tests/ParticleViewerTests
+
+# 6. (Optional) Static analysis
+clang-tidy src/main.cpp -- -Isrc/glad/include
 ```
 
 **⚠️ Critical:** Do NOT trust that `clang-format --dry-run -Werror` with no output means success. Always visually inspect `git diff` of modified files. Silent tool output can mask formatting issues.
+
+See `references/FORMATTING_RULES.md` for formatting rule details.
 
 ---
 
@@ -50,7 +63,15 @@ clang-tidy src/main.cpp -- -Isrc/glad/include  # optional
 
 ---
 
+## Adding a Feature / Fixing a Bug
+
+See `references/CPP_TOOLCHAIN.md` for PV-specific toolchain commands.
+
+---
+
 ## Code Smell Review Checklist
+
+Static analysis catches syntax violations. These structural smells require human review on every PR:
 
 - **DuplicatedCode** — Same logic block in 2+ places? Extract it.
 - **LongMethod** — Method longer than ~30 lines? Apply ExtractMethod.
@@ -62,6 +83,17 @@ See `references/CODE_SMELLS.md` for the full checklist.
 
 ✓ All checked → no structural smells found
 ✗ Any flagged → log `[BROKEN WINDOW NOTED]` or fix before commit (see `cpp-patterns` skill)
+
+See `references/CODE_SMELLS.md` for the full code smells catalog.
+
+---
+
+## Review Checklist
+
+See `references/REVIEW_CHECKLIST.md` for the full numbered pre-commit checklist.
+
+✓ All 10 met → proceed to commit
+✗ Any unmet → complete the failing step before committing
 
 ---
 

--- a/.github/skills/code-quality/references/CODE_SMELLS.md
+++ b/.github/skills/code-quality/references/CODE_SMELLS.md
@@ -287,3 +287,38 @@ When you detect a smell:
 
 ---
 
+
+---
+
+## Extended Code Smells Checklist
+
+| Smell | What to Look For |
+|---|---|
+| **FeatureEnvy** | Method references another class's data more than its own? Apply MoveMethod. |
+| **MagicNumber** | Literals in GL calls or formulas? Name them as constants. |
+| **ArrowAntiPattern** | More than 3 levels of nesting? Introduce guard clauses or RAII. |
+| **SpeculativeGenerality** | Abstraction with exactly one implementation? Remove it until a second arrives. |
+| **CommentSubstitutingForCode** | Comment explains WHAT the code does (not WHY)? Rename or refactor instead. |
+
+---
+
+## OAOO / DRY Principle
+
+## Code Duplication: Once And Only Once vs Don't Repeat Yourself
+
+These two principles are frequently conflated but target different problems:
+
+| Principle | Source | What it targets | How to fix |
+|-----------|--------|-----------------|------------|
+| **Once And Only Once** | Ward Cunningham / Extreme Programming | The same *code logic* appears in two or more places | Refactor: extract a method, function, or class |
+| **Don't Repeat Yourself** | Hunt & Thomas, *The Pragmatic Programmer* | The same *knowledge or fact* is encoded in two or more places, even if the code looks different | Introduce a single authoritative source of truth |
+
+**Key distinction:** Two code blocks can look identical yet not violate Don't Repeat Yourself if they represent two independent domain concepts that happen to look similar today. Merging them creates false coupling. Conversely, two code blocks can look completely different yet violate Don't Repeat Yourself if they both encode the same business rule.
+
+| Situation | Principle violated | Correct action |
+|-----------|-------------------|----------------|
+| Same validation logic repeated in three `if` blocks | Once And Only Once | Extract a `validate()` function |
+| Maximum buffer size duplicated as a constant and a comment | Don't Repeat Yourself | Remove the comment; the constant is the source of truth |
+| Two classes share a 3-line helper computing screen coordinates | Once And Only Once | Extract to a shared utility |
+| Database schema and response struct both define "a user has email and name" | Don't Repeat Yourself | Generate one from the other, or treat one as the source of truth |
+| Two unrelated features happen to iterate in the same way | Neither | Leave them separate; forced unification creates accidental coupling |

--- a/.github/skills/code-quality/references/CODE_SMELLS.md
+++ b/.github/skills/code-quality/references/CODE_SMELLS.md
@@ -287,9 +287,6 @@ When you detect a smell:
 
 ---
 
-
----
-
 ## Extended Code Smells Checklist
 
 | Smell | What to Look For |
@@ -301,8 +298,6 @@ When you detect a smell:
 | **CommentSubstitutingForCode** | Comment explains WHAT the code does (not WHY)? Rename or refactor instead. |
 
 ---
-
-## OAOO / DRY Principle
 
 ## Code Duplication: Once And Only Once vs Don't Repeat Yourself
 

--- a/.github/skills/code-quality/references/CPP_TOOLCHAIN.md
+++ b/.github/skills/code-quality/references/CPP_TOOLCHAIN.md
@@ -44,3 +44,27 @@ Configuration in `.clang-tidy` enforces:
 Header filter excludes embedded libs: `glad`, `tinyFileDialogs`, `stb_*`.
 
 **CI status:** clang-tidy runs in CI as advisory (non-blocking). clang-format is blocking.
+
+---
+
+# PV Workflow Patterns
+
+## Step 7: Adding a Feature / Fixing a Bug
+
+### New Feature Workflow
+1. **Scan the class interface** — before writing integration code that calls methods on an existing class, verify which members are public/private. Classes like `Camera` have a mix; don't assume public.
+2. Make code changes following naming conventions
+3. Add unit tests in `tests/core/` (see `testing` skill)
+4. Run `clang-format -i` on ALL changed files
+5. Build and verify tests pass
+6. Commit: `feat: description`
+
+### Removing Features / User-Requested Changes
+When removing a gamepad feature or call site from `viewer_app.cpp` at user request, **do not also delete the supporting `Camera` public method**. The Camera API is stable across sessions; call sites in `viewer_app` change frequently with user preferences. Removing `isRenderingSphere()` when L3/R3 was dropped meant restoring it when L3/R3 came back one session later. Only remove a Camera method if it is architecturally wrong, not merely unused at the current moment.
+
+### Bug Fix Workflow
+1. Write a failing test that reproduces the bug
+2. Fix the code
+3. Verify test passes, run full suite
+4. Run `clang-format -i` on changed files
+5. Commit: `fix: description`

--- a/.github/skills/code-quality/references/CPP_TOOLCHAIN.md
+++ b/.github/skills/code-quality/references/CPP_TOOLCHAIN.md
@@ -68,3 +68,15 @@ When removing a gamepad feature or call site from `viewer_app.cpp` at user reque
 3. Verify test passes, run full suite
 4. Run `clang-format -i` on changed files
 5. Commit: `fix: description`
+
+---
+
+# How This Skill is Invoked
+
+## Instructions for Agent
+
+In VS Code, users will activate this skill by:
+- Typing `@workspace /code-quality [description]` in Copilot Chat
+- Or asking: "Format the code", "Fix clang-tidy warnings", "What naming convention?", "Pre-commit checklist"
+
+When activated, apply the formatting, naming, and pattern rules below.

--- a/.github/skills/code-quality/references/CPP_TOOLCHAIN.md
+++ b/.github/skills/code-quality/references/CPP_TOOLCHAIN.md
@@ -47,7 +47,7 @@ Header filter excludes embedded libs: `glad`, `tinyFileDialogs`, `stb_*`.
 
 ---
 
-# PV Workflow Patterns
+## PV Workflow Patterns
 
 ## Step 7: Adding a Feature / Fixing a Bug
 

--- a/.github/skills/code-quality/references/CPP_TOOLCHAIN.md
+++ b/.github/skills/code-quality/references/CPP_TOOLCHAIN.md
@@ -69,14 +69,4 @@ When removing a gamepad feature or call site from `viewer_app.cpp` at user reque
 4. Run `clang-format -i` on changed files
 5. Commit: `fix: description`
 
----
 
-# How This Skill is Invoked
-
-## Instructions for Agent
-
-In VS Code, users will activate this skill by:
-- Typing `@workspace /code-quality [description]` in Copilot Chat
-- Or asking: "Format the code", "Fix clang-tidy warnings", "What naming convention?", "Pre-commit checklist"
-
-When activated, apply the formatting, naming, and pattern rules below.

--- a/.github/skills/code-quality/references/FORMATTING_RULES.md
+++ b/.github/skills/code-quality/references/FORMATTING_RULES.md
@@ -1,0 +1,10 @@
+# Human-Reviewable Formatting Patterns
+
+These require **manual inspection** after running clang-format — tools don't always catch them:
+
+| Issue | Fix | Example |
+|-------|-----|---------|
+| Semicolon after function closing brace | Remove trailing `;` | `void foo() { }` not `void foo() { };` |
+| Empty constructor syntax | Use `= default` | `Shader() = default;` not `Shader() {};` |
+| Exception catching by value | Catch by const reference | `catch (const std::ifstream::failure& e)` |
+| Multiple declarations in one line | Split to separate lines | `uint32_t w; uint32_t h;` not `uint32_t w, h;` |

--- a/.github/skills/code-quality/references/FORMATTING_RULES.md
+++ b/.github/skills/code-quality/references/FORMATTING_RULES.md
@@ -8,3 +8,5 @@ These require **manual inspection** after running clang-format — tools don't a
 | Empty constructor syntax | Use `= default` | `Shader() = default;` not `Shader() {};` |
 | Exception catching by value | Catch by const reference | `catch (const std::ifstream::failure& e)` |
 | Multiple declarations in one line | Split to separate lines | `uint32_t w; uint32_t h;` not `uint32_t w, h;` |
+
+**Always check `git diff` for these patterns after formatting.**

--- a/.github/skills/code-quality/references/INVOCATION.md
+++ b/.github/skills/code-quality/references/INVOCATION.md
@@ -1,0 +1,9 @@
+# How This Skill is Invoked
+
+## Instructions for Agent
+
+In VS Code, users will activate this skill by:
+- Typing `@workspace /code-quality [description]` in Copilot Chat
+- Or asking: "Format the code", "Fix clang-tidy warnings", "What naming convention?", "Pre-commit checklist"
+
+When activated, apply the formatting, naming, and pattern rules below.

--- a/.github/skills/code-quality/references/INVOCATION.md
+++ b/.github/skills/code-quality/references/INVOCATION.md
@@ -6,4 +6,4 @@ In VS Code, users will activate this skill by:
 - Typing `@workspace /code-quality [description]` in Copilot Chat
 - Or asking: "Format the code", "Fix clang-tidy warnings", "What naming convention?", "Pre-commit checklist"
 
-When activated, apply the formatting, naming, and pattern rules below.
+When activated, apply the formatting, naming, and pattern rules in this skill.

--- a/.github/skills/code-quality/references/NAMING_TABLES.md
+++ b/.github/skills/code-quality/references/NAMING_TABLES.md
@@ -1,0 +1,14 @@
+# Naming Convention Tables
+
+## Naming Conventions by Category
+
+| Element | Convention | Example |
+|---------|-----------|---------|
+| Classes/Structs/Enums | `PascalCase` | `ParticleSystem`, `RenderSettings` |
+| Functions/Methods | `camelCase` (USE camelCase; not enforced by clang-tidy) | `initializeBuffers`, `getParticleCount` |
+| Variables/Parameters | `snake_case` | `particle_count`, `delta_time` |
+| Member variables | `snake_case` + trailing `_` for private | `window_width`, `camera_` |
+| Constants/Macros | `UPPER_CASE` | `MAX_PARTICLES`, `PI` |
+| File names | `snake_case` | `particle_system.hpp` |
+| Include guards | `<PROJECT>_<PATH>_<FILE>_H` | `PARTICLE_VIEWER_PARTICLE_SYSTEM_H` |
+| Namespaces | `snake_case` | `particle_viewer` |

--- a/.github/skills/code-quality/references/REVIEW_CHECKLIST.md
+++ b/.github/skills/code-quality/references/REVIEW_CHECKLIST.md
@@ -1,7 +1,5 @@
 # Pre-Review Checklist
 
-## Review Checklist
-
 - [ ] `clang-format -i` run on all changed files
 - [ ] `clang-format --dry-run -Werror` passes
 - [ ] Build succeeds

--- a/.github/skills/code-quality/references/REVIEW_CHECKLIST.md
+++ b/.github/skills/code-quality/references/REVIEW_CHECKLIST.md
@@ -1,0 +1,17 @@
+# Pre-Review Checklist
+
+## Review Checklist
+
+- [ ] `clang-format -i` run on all changed files
+- [ ] `clang-format --dry-run -Werror` passes
+- [ ] Build succeeds
+- [ ] All tests pass
+- [ ] Conventional commit message format used
+- [ ] No raw `new`/`delete` — use RAII or smart pointers
+- [ ] GL resources cleaned up in destructors
+- [ ] Headers are self-contained
+- [ ] If a public interface changed: documentation updated in same commit (see cpp-patterns skill)
+- [ ] If a symbol is deprecated: all call sites removed or annotated (see cpp-patterns skill)
+
+✓ All 10 met → proceed to commit
+✗ Any unmet → complete the failing step before committing

--- a/.github/skills/execution/SKILL.md
+++ b/.github/skills/execution/SKILL.md
@@ -204,6 +204,8 @@ For the domain-to-skill dispatch lookup, see `references/EXECUTION_PATTERNS.md`.
 | "I'll review the spec compliance myself, no need to dispatch" | You wrote the code — you will rationalize away the gaps. Dispatch spec-compliance-reviewer.md every time. |
 | "The previous todo had no issues, this one is probably fine too" | Each todo is independent. Prior clean reviews do not carry over. Dispatch reviewers after this todo. |
 | "I'm close to the end, I'll skip the Skeptic for this todo" | End-of-plan todos are the most likely to drift from the original scope. The Skeptic Agent is mandatory regardless of position in the plan. |
+| "Inline nit fix is trivial, no review needed" | Inline fixes are unverified by default. If the fix is a structural change (heading level, path format, sentence replacement), dispatch a re-review or apply only to content you can verify in the same view call. |
+| "After a rate limit, I can resume dispatching immediately — my last checkpoint shows what was in flight" | A rate limit severs the agent's awareness of what agents completed, errored, or were interrupted. Dispatch a validation-only batch first and wait for the result before dispatching any continuation agents. |
 
 ---
 

--- a/.github/skills/execution/SKILL.md
+++ b/.github/skills/execution/SKILL.md
@@ -209,7 +209,7 @@ For the domain-to-skill dispatch lookup, see `references/EXECUTION_PATTERNS.md`.
 
 ## Quick Reference
 
-**Execution patterns (Profile Before Optimizing, Assign Problems Not Tasks, Technical Debt Visibility):** `.github/skills/execution/references/EXECUTION_PATTERNS.md`
+**Execution patterns (Profile Before Optimizing, Assign Problems Not Tasks, Technical Debt Visibility):** `references/EXECUTION_PATTERNS.md`
 
 ```
 Task arrives

--- a/.github/skills/execution/SKILL.md
+++ b/.github/skills/execution/SKILL.md
@@ -35,15 +35,11 @@ For completion claims → invoke **verification-before-completion** skill.
 
 ### Keep Commitments
 
-When you announce what you will do — in the session-start announcement, in a plan summary, or in a response — those statements are **commitments**, not intentions.
-
 **Rules:**
 - Every announced item must be delivered, OR explicitly acknowledged as undelivered before the response ends
 - The format for a missed commitment: `COMMITMENT NOT MET: I committed to [X]. I could not complete it because [specific reason]. Next step: [concrete action]`
 - Never let a commitment expire silently — do not end a response with an announced item quietly dropped
 - "I'll get to it next turn" is not a completion — only "I completed X, verified by [evidence]" is
-
-This behavior is the foundation of predictable trust. Consistent commitment-keeping means the user can plan around your output without second-guessing whether announced work was actually done.
 
 **Mid-session expectations drift:** If user feedback mid-session reveals your understanding of a requirement was wrong, stop and re-execute Step 0 (Clarify Expectations) before continuing. Do not silently absorb the correction and continue on the old plan.
 
@@ -65,22 +61,13 @@ For every planned item, before writing code:
 8. Advance to the next item
 ```
 
-**A task is not done until both reviewer stages pass.** Tests green is necessary but not sufficient.
-
-- Clean compilation
-- All tests green
-- Diff reviewed for side-effects
-- Stage 1 (spec compliance): PASS
-- Stage 2 (code quality): APPROVE or APPROVE WITH NITS resolved
-
 
 ### Communicating Progress
 
 - Summarize at the milestone level, not the keystroke level
 - State what changed, what was validated, and what comes next
-- When all items are complete, give a brief accounting of files touched, tests added, and notable decisions
-- **Temporal declaration:** When a plan requires more turns than the user likely expects, state this proactively at plan time: "This will take approximately N responses. Here is what each will deliver: [sequence]." Do not surface this mid-execution — declare it at plan time.
-- **Attention cost:** Before sending any response longer than 200 words or creating new work for the user, ask: is this the most respectful use of their attention? Compress or defer non-essential content.
+
+For temporal declaration and attention cost rules, see `references/EXECUTION_PATTERNS.md`.
 
 ### Commit Rhythm
 
@@ -133,30 +120,15 @@ After something works but before you commit: **"Is there a cleaner way to expres
 
 ### Trade-Off Discipline
 
-When two or more valid approaches exist, use this structure:
-```
-Approach A: [what it gives] / [what it costs]
-Approach B: [what it gives] / [what it costs]
-Choice: [A or B] because [specific reason]
-```
-
-Required when: rejecting a simpler approach, making a correctness/performance/maintainability tradeoff, or when the choice affects testability or coupling.
-
-**Pain as Signal:** Difficult-to-test code signals a design problem. Fix the design, not the test harness.
+For trade-off discipline structure and the Approach A/B/Choice template, see `references/EXECUTION_PATTERNS.md`.
 
 ---
 
 ## Make It Work, Make It Right, Make It Fast
 
-This three-phase progression, from Kent Beck, governs the order of quality concerns at the feature level:
-
 1. **Make it work** — pass the tests; behavior is correct
 2. **Make it right** — refactor: clean design, no duplication, clear names
 3. **Make it fast** — optimize: only after correctness and cleanliness are established
-
-**Relationship to the TDD cycle:**
-
-The TDD Red/Green/Refactor cycle enforces Make It Work → Make It Right at the *micro level* (each individual test). This macro rule enforces the same discipline at the *feature level*: do not optimize code that does not yet pass its tests; do not clean up code that does not yet work.
 
 **Gates:**
 
@@ -196,37 +168,17 @@ When a mistake is discovered:
 
 **Symmetric Right Wrongs:** If a user instruction will produce a defective result, say so before acting: "I'll proceed if you confirm, but this will cause [specific consequence]."
 
-**Listen First:** Read the user's feedback fully before drafting any response. A defense written before the criticism is understood is a collision, not a response.
-
 ---
 
 ## Continuous Refinement
 
-After any mistake or user correction:
-
-1. Name the failure mode
-2. Check existing skills — is it already documented?
-3. If new, update the relevant skill now — don't defer
-4. Write a concrete prevention rule
+After a mistake, apply the Continuous Refinement protocol — see `references/EXECUTION_PATTERNS.md`.
 
 ---
 
 ## Skill Dispatch Table
 
-| Domain | Skill |
-|--------|-------|
-| Planning a multi-step task | `writing-plans` |
-| Subagent dispatch or delegation | `subagent-driven-development` |
-| Bug or failure | `systematic-debugging` |
-| Completion claim | `verification-before-completion` |
-| Writing tests | `testing` |
-| Writing/editing C++ | `code-quality` |
-| Commits or PRs | `versioning` |
-| CI/CD work | `workflow` |
-| Flatpak packaging or GL runtime | `flatpak` |
-| Build or dependencies | `build` |
-| Code review | `code-review agent`, 1 per file |
-| Skill review | `general-purpose` + `skill-reviewer` skill |
+For the domain-to-skill dispatch lookup, see `references/EXECUTION_PATTERNS.md`.
 
 ---
 

--- a/.github/skills/execution/SKILL.md
+++ b/.github/skills/execution/SKILL.md
@@ -142,6 +142,8 @@ For trade-off discipline structure and the Approach A/B/Choice template, see `re
 - Refactoring while tests are red (behavior is unknown)
 - Profiling before a clean design exists (profiling a mess optimizes the wrong thing)
 
+For the relationship between MIWMIRMIF and the TDD cycle, see `references/EXECUTION_PATTERNS.md`.
+
 ---
 
 ### Mode Declaration

--- a/.github/skills/execution/references/EXECUTION_PATTERNS.md
+++ b/.github/skills/execution/references/EXECUTION_PATTERNS.md
@@ -92,3 +92,63 @@ Address the source of friction rather than working around it. A system that is h
 - `execution` — work loop, commit rhythm, mode declaration
 - `writing-plans` — SIMPLICITY_PRINCIPLES.md for Assign Problems Not Tasks; YAGNI gate
 - `systematic-debugging` — Profile Before Optimizing applies equally to debugging: measure before concluding
+
+---
+
+## Trade-Off Discipline
+
+When two or more valid approaches exist, use this structure:
+```
+Approach A: [what it gives] / [what it costs]
+Approach B: [what it gives] / [what it costs]
+Choice: [A or B] because [specific reason]
+```
+
+Required when: rejecting a simpler approach, making a correctness/performance/maintainability tradeoff, or when the choice affects testability or coupling.
+
+**Pain as Signal:** Difficult-to-test code signals a design problem. Fix the design, not the test harness.
+
+---
+
+## MIWMIRMIF — Extended Rationale
+
+**Relationship to the TDD cycle:**
+
+The TDD Red/Green/Refactor cycle enforces Make It Work → Make It Right at the *micro level* (each individual test). This macro rule enforces the same discipline at the *feature level*: do not optimize code that does not yet pass its tests; do not clean up code that does not yet work.
+
+---
+
+## Continuous Refinement
+
+After any mistake or user correction:
+
+1. Name the failure mode
+2. Check existing skills — is it already documented?
+3. If new, update the relevant skill now — don't defer
+4. Write a concrete prevention rule
+
+---
+
+## Skill Dispatch Table
+
+| Domain | Skill |
+|--------|-------|
+| Planning a multi-step task | `writing-plans` |
+| Subagent dispatch or delegation | `subagent-driven-development` |
+| Bug or failure | `systematic-debugging` |
+| Completion claim | `verification-before-completion` |
+| Writing tests | `testing` |
+| Writing/editing C++ | `code-quality` |
+| Commits or PRs | `versioning` |
+| CI/CD work | `workflow` |
+| Flatpak packaging or GL runtime | `flatpak` |
+| Build or dependencies | `build` |
+| Code review | `code-review agent`, 1 per file |
+| Skill review | `general-purpose` + `skill-reviewer` skill |
+
+---
+
+## Communicating Progress — Extended Rules
+
+- **Temporal declaration:** When a plan requires more turns than the user likely expects, state this proactively at plan time: "This will take approximately N responses. Here is what each will deliver: [sequence]." Do not surface this mid-execution — declare it at plan time.
+- **Attention cost:** Before sending any response longer than 200 words or creating new work for the user, ask: is this the most respectful use of their attention? Compress or defer non-essential content.

--- a/.github/skills/execution/references/EXECUTION_PATTERNS.md
+++ b/.github/skills/execution/references/EXECUTION_PATTERNS.md
@@ -116,6 +116,8 @@ When you announce what you will do — in the session-start announcement, in a p
 
 This behavior is the foundation of predictable trust. Consistent commitment-keeping means the user can plan around your output without second-guessing whether announced work was actually done.
 
+---
+
 ## Right Wrongs — Extended Rules
 
 **Listen First:** Read the user's feedback fully before drafting any response. A defense written before the criticism is understood is a collision, not a response.
@@ -164,3 +166,4 @@ After any mistake or user correction:
 
 - **Temporal declaration:** When a plan requires more turns than the user likely expects, state this proactively at plan time: "This will take approximately N responses. Here is what each will deliver: [sequence]." Do not surface this mid-execution — declare it at plan time.
 - **Attention cost:** Before sending any response longer than 200 words or creating new work for the user, ask: is this the most respectful use of their attention? Compress or defer non-essential content.
+- When all items are complete, give a brief accounting of files touched, tests added, and notable decisions.

--- a/.github/skills/execution/references/EXECUTION_PATTERNS.md
+++ b/.github/skills/execution/references/EXECUTION_PATTERNS.md
@@ -110,6 +110,18 @@ Required when: rejecting a simpler approach, making a correctness/performance/ma
 
 ---
 
+## Keep Commitments — Extended Rationale
+
+When you announce what you will do — in the session-start announcement, in a plan summary, or in a response — those statements are **commitments**, not intentions.
+
+This behavior is the foundation of predictable trust. Consistent commitment-keeping means the user can plan around your output without second-guessing whether announced work was actually done.
+
+## Right Wrongs — Extended Rules
+
+**Listen First:** Read the user's feedback fully before drafting any response. A defense written before the criticism is understood is a collision, not a response.
+
+---
+
 ## MIWMIRMIF — Extended Rationale
 
 **Relationship to the TDD cycle:**

--- a/.github/skills/session-bootstrap/SKILL.md
+++ b/.github/skills/session-bootstrap/SKILL.md
@@ -46,39 +46,9 @@ If neither hook output is visible in context, load `honesty` explicitly before r
 
 ## On Start — Minimum Skill Loads by Task Type
 
-Before writing code, read the skill(s) relevant to your task. `honesty` is injected by hook — load it explicitly only if hook output is absent.
+Before writing code, read the skill(s) relevant to your task. `honesty` is injected by hook — load it explicitly only if hook output is absent. If the task touches multiple domains, read multiple skills in parallel (they are independent reads).
 
-Before writing code, read the skill(s) relevant to your task. If the task touches multiple
-domains, read multiple skills in parallel (they are independent reads).
-
-| If the task involves…                        | MUST read these skills BEFORE acting               |
-|----------------------------------------------|----------------------------------------------------|
-| Any implementation work                      | `execution`                                        |
-| Planning a multi-step task                   | `writing-plans`                                    |
-| Unclear approach or design choices           | `brainstorming`                                    |
-| Writing or editing code                      | `execution`, `code-quality`                        |
-| Writing code with rendering/runtime patterns | `execution`, `code-quality`, `cpp-patterns`        |
-| Writing or editing tests                     | `execution`, `code-quality`, `testing`             |
-| Writing visual regression tests              | `execution`, `code-quality`, `testing`, `visual-regression-testing` |
-| Creating a PR or commit                      | `versioning`, `verification-before-completion`     |
-| Finishing / closing a branch                 | `finishing-a-development-branch`                   |
-| Requesting code review                       | `requesting-code-review`                           |
-| Receiving code review feedback               | `receiving-code-review`                            |
-| CI/CD or workflow changes                    | `workflow`                                         |
-| Flatpak packaging or GL runtime              | `flatpak`                                          |
-| Build system or dependency changes           | `build`                                            |
-| Writing or editing documentation             | `documentation`                                    |
-| Bug fixes or error resolution                | `execution`, `systematic-debugging`                |
-| Any failure or unexpected behavior           | `systematic-debugging`, `verification-before-completion` |
-| Dispatching subagents                        | `subagent-driven-development`                      |
-| Parallel agent work / A/B testing            | `subagent-driven-development`, `using-git-worktrees` |
-| Creating user stories                        | `user-story-generator`, `user-story-estimation`    |
-| Creating or editing a skill file             | `writing-skills`, `skill-reviewer`                 |
-| Resuming from a prior session with pending SQL todos | `writing-plans`; dispatch Skeptic before first implementation step |
-| Schema design, new data structure, or plan with ≥5 implementation items | `brainstorming`, `writing-plans` |
-| Auditing communication quality or postmortem | `honesty`, `session-postmortem`                    |
-| Any new plan with 2+ todos | `writing-plans`; dispatch Skeptic before first implementation step |
-| Auditing or reorganizing a collection of files, tasks, or artifacts with multiple valid structural approaches | `brainstorming`, `writing-plans` |
+See `references/SKILL_DISPATCH_TABLE.md` for the full skill-by-task-type dispatch table.
 
 If unsure, read `code-quality` — it applies to every code task.
 
@@ -109,26 +79,7 @@ If unsure, read `code-quality` — it applies to every code task.
 
 ## On Finish — Self-Evaluate and Compact
 
-**Self-evaluation fires at session END.** If a major task completes mid-session with no further work planned, treat it as session end and execute On Finish now.
-
-**Before your final message to the user**, execute all of the following:
-
-1. **Read** `.github/skills/self-evaluation/SKILL.md` and follow its steps.
-2. **Identify lessons learned** — mistakes made, user corrections, patterns discovered.
-3. **Check existing skills** — is the lesson already documented? If yes, skip.
-4. **Apply updates** — for High/Medium priority lessons, update the relevant skill file
-   and bump its version in the YAML frontmatter. Commit the skill update with the
-   session's work.
-5. **Compact** — scan any files you touched for bloated comments or duplicated docs.
-   Migrate detail to skills/docs and leave 1-line references.
-6. **Report** — include a `### Session Self-Evaluation` block in your final message:
-   ```
-   ### Session Self-Evaluation
-   Lessons: [count] | Skills updated: [list or "None"] | Compacted: [files or "None"]
-   ```
-
-If you have nothing to report, still include the block with zeroes. This ensures the
-behavior is habitual, not conditional.
+Load the `self-evaluation` skill and follow its steps.
 
 ---
 
@@ -138,11 +89,9 @@ behavior is habitual, not conditional.
 - Starting implementation when SQL has pending todos from a prior session without dispatching Skeptic — **STOP. Dispatch Skeptic before the first implementation step.**
 - Starting to code before reading the required skill — **STOP. Load the skill now. Do not write one line first.**
 - Skipping the skill-load announcement — **STOP. State "I am using the [skill] skill to [purpose]." No skip.**
-- Finishing a session without running `self-evaluation` — **STOP. Read `.github/skills/self-evaluation/SKILL.md` now.**
-- Treating the "On Finish" steps as optional — **STOP. They are mandatory. Execute every step.**
-- Saying "I remember the skill content" — **STOP. Memory degrades. Skills update. Load fresh every session.**
-- Branch about to be created, but the plan the user approved was the pre-Skeptic version — **STOP. Re-present the post-Skeptic revised plan. Wait for explicit user approval before creating the branch.**
-- About to make an irreversible change (branch creation, push) without the `execution` skill loaded — **STOP. Load `execution` before the first irreversible action.**
+- Finishing a session without running `self-evaluation` — **STOP. Load the `self-evaluation` skill now.**
+
+See `references/EXTENDED_CHECKS.md` for additional Red Flags.
 
 ---
 
@@ -155,9 +104,8 @@ behavior is habitual, not conditional.
 | "I'll self-evaluate if anything went wrong"        | Self-evaluation finds what you didn't notice wrong | Always self-evaluate. No conditional.      |
 | "Skipping announcement to save space"              | Announcement is the commitment mechanism           | State it. No skip.                         |
 | "I'll skim the skill — I know the gist"            | Skimming misses updates and specific gate conditions | Read fully. The gate conditions are the point. |
-| "'Always active' means I don't need to invoke honesty" | The declaration activates the rule reference, not the rule body. Without invocation, the confidence vocabulary and process language rules are absent. | Invoke `honesty` explicitly. Every session. |
-| "I ran the hook script and it exited 0 — hooks are working" | Script execution ≠ CLI mechanism. The CLI reads hooks.json once at session start. An in-session fix to hooks.json is NOT active until the next session. Do not claim hooks are working until a new session confirms hook.end success=true. |
-| "I'm just gathering context, not reviewing"        | Research reading to inform a plan is still review. Inline review is biased by your assumptions. | Dispatch an explore or code-review agent for any 3+ file research task. |
+
+See `references/EXTENDED_CHECKS.md` for additional rationalization entries.
 
 ## Related Skills
 

--- a/.github/skills/session-bootstrap/references/EXTENDED_CHECKS.md
+++ b/.github/skills/session-bootstrap/references/EXTENDED_CHECKS.md
@@ -5,7 +5,7 @@
 | Rationalization                                    | Why it fails                                       | Correct action                              |
 |----------------------------------------------------|----------------------------------------------------|---------------------------------------------|
 | "'Always active' means I don't need to invoke honesty" | The declaration activates the rule reference, not the rule body. Without invocation, the confidence vocabulary and process language rules are absent. | Invoke `honesty` explicitly. Every session. |
-| "I ran the hook script and it exited 0 — hooks are working" | Script execution ≠ CLI mechanism. The CLI reads hooks.json once at session start. An in-session fix to hooks.json is NOT active until the next session. Do not claim hooks are working until a new session confirms hook.end success=true. | Wait for the next session start to confirm hook.end success=true. |
+| "I ran the hook script and it exited 0 — hooks are working" | Script execution ≠ CLI mechanism. The CLI reads hooks.json once at session start. An in-session fix to hooks.json is NOT active until the next session. Do not claim hooks are working until a new session confirms hook.end success=true. |
 | "I'm just gathering context, not reviewing"        | Research reading to inform a plan is still review. Inline review is biased by your assumptions. | Dispatch an explore or code-review agent for any 3+ file research task. |
 
 ## Additional Red Flags

--- a/.github/skills/session-bootstrap/references/EXTENDED_CHECKS.md
+++ b/.github/skills/session-bootstrap/references/EXTENDED_CHECKS.md
@@ -1,0 +1,16 @@
+# Extended Checks — Overflow Items
+
+## Additional Rationalization Entries
+
+| Rationalization                                    | Why it fails                                       | Correct action                              |
+|----------------------------------------------------|----------------------------------------------------|---------------------------------------------|
+| "'Always active' means I don't need to invoke honesty" | The declaration activates the rule reference, not the rule body. Without invocation, the confidence vocabulary and process language rules are absent. | Invoke `honesty` explicitly. Every session. |
+| "I ran the hook script and it exited 0 — hooks are working" | Script execution ≠ CLI mechanism. The CLI reads hooks.json once at session start. An in-session fix to hooks.json is NOT active until the next session. Do not claim hooks are working until a new session confirms hook.end success=true. | Wait for the next session start to confirm hook.end success=true. |
+| "I'm just gathering context, not reviewing"        | Research reading to inform a plan is still review. Inline review is biased by your assumptions. | Dispatch an explore or code-review agent for any 3+ file research task. |
+
+## Additional Red Flags
+
+- Treating the "On Finish" steps as optional — **STOP. They are mandatory. Execute every step.**
+- Saying "I remember the skill content" — **STOP. Memory degrades. Skills update. Load fresh every session.**
+- Branch about to be created, but the plan the user approved was the pre-Skeptic version — **STOP. Re-present the post-Skeptic revised plan. Wait for explicit user approval before creating the branch.**
+- About to make an irreversible change (branch creation, push) without the `execution` skill loaded — **STOP. Load `execution` before the first irreversible action.**

--- a/.github/skills/session-bootstrap/references/EXTENDED_CHECKS.md
+++ b/.github/skills/session-bootstrap/references/EXTENDED_CHECKS.md
@@ -4,7 +4,7 @@
 
 | Rationalization                                    | Why it fails                                       | Correct action                              |
 |----------------------------------------------------|----------------------------------------------------|---------------------------------------------|
-| "'Always active' means I don't need to invoke honesty" | The declaration activates the rule reference, not the rule body. Without invocation, the confidence vocabulary and process language rules are absent. | Invoke `honesty` explicitly. Every session. |
+| "'Always active' means I don't need to invoke honesty" | The declaration activates the rule reference, not the rule body. Without invocation, the confidence vocabulary and process language rules are absent. | Ensure `honesty` content is present every session; if hook output is missing, invoke it explicitly. |
 | "I ran the hook script and it exited 0 — hooks are working" | Script execution ≠ CLI mechanism. The CLI reads hooks.json once at session start. An in-session fix to hooks.json is NOT active until the next session. Do not claim hooks are working until a new session confirms hook.end success=true. |
 | "I'm just gathering context, not reviewing"        | Research reading to inform a plan is still review. Inline review is biased by your assumptions. | Dispatch an explore or code-review agent for any 3+ file research task. |
 

--- a/.github/skills/session-bootstrap/references/SKILL_DISPATCH_TABLE.md
+++ b/.github/skills/session-bootstrap/references/SKILL_DISPATCH_TABLE.md
@@ -3,7 +3,8 @@
 | If the task involves…                        | MUST read these skills BEFORE acting               |
 |----------------------------------------------|----------------------------------------------------|
 | Any implementation work                      | `execution`                                        |
-| Planning a multi-step task or any new plan with 2+ todos | `writing-plans`; dispatch Skeptic before first implementation step |
+| Planning a multi-step task                   | `writing-plans`                                    |
+| Any new plan with 2+ todos | `writing-plans`; dispatch Skeptic before first implementation step |
 | Unclear approach or design choices           | `brainstorming`                                    |
 | Writing or editing code                      | `execution`, `code-quality`                        |
 | Writing code with rendering/runtime patterns | `execution`, `code-quality`, `cpp-patterns`        |

--- a/.github/skills/session-bootstrap/references/SKILL_DISPATCH_TABLE.md
+++ b/.github/skills/session-bootstrap/references/SKILL_DISPATCH_TABLE.md
@@ -1,0 +1,29 @@
+# On Start — Skill Dispatch Table
+
+| If the task involves…                        | MUST read these skills BEFORE acting               |
+|----------------------------------------------|----------------------------------------------------|
+| Any implementation work                      | `execution`                                        |
+| Planning a multi-step task or any new plan with 2+ todos | `writing-plans`; dispatch Skeptic before first implementation step |
+| Unclear approach or design choices           | `brainstorming`                                    |
+| Writing or editing code                      | `execution`, `code-quality`                        |
+| Writing code with rendering/runtime patterns | `execution`, `code-quality`, `cpp-patterns`        |
+| Writing or editing tests                     | `execution`, `code-quality`, `testing`             |
+| Writing visual regression tests              | `execution`, `code-quality`, `testing`, `visual-regression-testing` |
+| Creating a PR or commit                      | `versioning`, `verification-before-completion`     |
+| Finishing / closing a branch                 | `finishing-a-development-branch`                   |
+| Requesting code review                       | `requesting-code-review`                           |
+| Receiving code review feedback               | `receiving-code-review`                            |
+| CI/CD or workflow changes                    | `workflow`                                         |
+| Flatpak packaging or GL runtime              | `flatpak`                                          |
+| Build system or dependency changes           | `build`                                            |
+| Writing or editing documentation             | `documentation`                                    |
+| Bug fixes or error resolution                | `execution`, `systematic-debugging`                |
+| Any failure or unexpected behavior           | `systematic-debugging`, `verification-before-completion` |
+| Dispatching subagents                        | `subagent-driven-development`                      |
+| Parallel agent work / A/B testing            | `subagent-driven-development`, `using-git-worktrees` |
+| Creating user stories                        | `user-story-generator`, `user-story-estimation`    |
+| Creating or editing a skill file             | `writing-skills`, `skill-reviewer`                 |
+| Resuming from a prior session with pending SQL todos | `writing-plans`; dispatch Skeptic before first implementation step |
+| Schema design, new data structure, or plan with ≥5 implementation items | `brainstorming`, `writing-plans` |
+| Auditing communication quality or postmortem | `honesty`, `session-postmortem`                    |
+| Auditing or reorganizing a collection of files, tasks, or artifacts with multiple valid structural approaches | `brainstorming`, `writing-plans` |

--- a/.github/skills/session-postmortem/SKILL.md
+++ b/.github/skills/session-postmortem/SKILL.md
@@ -20,8 +20,6 @@ YOU MUST examine the session for rationalization patterns. A clean outcome does 
 
 ## BEFORE PROCEEDING — Postmortem Gate
 
-Before starting the postmortem analysis:
-
 1. The session being analyzed has completed — no further work is planned for that session.
 2. The session's `events.jsonl` log is accessible at `[SESSION_ID]/events.jsonl`.
 3. You are running as an EXTERNAL reviewer — you have not been the agent in the session being analyzed.
@@ -31,238 +29,37 @@ Before starting the postmortem analysis:
 
 ---
 
-## The Blameless Principle
-
-This postmortem is about **decisions and systems**, not character. Every failure is a decision that could be better-gated or better-informed. The language in the report must reflect this.
-
-| Blameful (forbidden) | Blameless (required) |
-|----------------------|---------------------|
-| "The agent was careless" | "The planning gate was not applied before code was written" |
-| "The agent didn't follow the rules" | "The rationalization table did not cover this excuse pattern" |
-| "The agent got lucky" | "The process produced a correct outcome by path rather than by gate" |
-| "The agent lied" | "The confidence vocabulary gate was not active for this claim type" |
-
-The goal is not to evaluate the agent — it is to find the gaps in the system that allowed the failure to occur undetected. A gap found is a skill improvement waiting to be written.
-
----
-
-## Difference From Self-Evaluation
-
-| Skill | Who runs it | When | What it analyzes |
-|-------|-------------|------|-----------------|
-| `self-evaluation` | The agent itself | At the end of its own session | Outcomes, lessons, skill updates |
-| `session-postmortem` | A different agent or human reviewer | After a session closes | Agent *behavior* patterns during the session |
-
-Self-evaluation captures what was learned. Session postmortem finds where the agent rationalized, bypassed laws, or got lucky.
-
----
-
-## External Reviewer Protocol (Required)
-
-A self-assessment cannot find what the agent rationalized away. **An external reviewer reads the raw event log cold — no session memory, no emotional investment in the outcome.** This is not optional. A postmortem with only self-assessment is incomplete.
-
-### Setup
-
-Derive the paths for the session being reviewed from your project's session management conventions. For Particle-Viewer path conventions, see `references/PV_SESSION_PATHS.md`.
-
-### Protocol
-
-1. **Dispatch the external reviewer subagent** using `.github/agents/postmortem-reviewer.md` with the above paths filled in. The reviewer reads `events.jsonl` directly — no pre-export needed.
-
-2. **Run self-assessment in parallel** (the main agent does Parts 1–5 from memory while the reviewer works). **INDEPENDENCE GATE: Write the self-assessment FROM MEMORY ONLY — do NOT read `events.jsonl`, checkpoints, `plan.md`, or any session artifact before writing `postmortem.md`. `postmortem.md` MUST be created on disk before you read any source data. Only after the file exists may you read session data or wait for the external review to complete. Reading session artifacts first means the self-assessment is a log summary, not independent assessment. Do NOT announce yourself as "external reviewer" or "cold read" in your own context — that role belongs exclusively to the dispatched subagent.**
-
-   **If `postmortem.md` already exists** (multi-phase session): do NOT read its content to find an append anchor. Append with `## Phase N: [Task Name]` — construct a unique section heading without reading the existing file. "Finding the anchor" is not an exemption from the independence gate.
-
-3. **Wait for the reviewer to complete.** Read its output from `postmortem-external.md`. **The only permissible action between dispatching the external reviewer and `read_agent` returning is polling (`read_agent`). Do NOT announce a verdict, summarize findings, or output any assessment until `read_agent` returns. A verdict announced before the external review completes will be based on incomplete information and may directly contradict the reviewer's log-cited findings.**
-
-4. **Reconcile.** Where the external reviewer and self-assessment agree: note the convergence. Where they conflict: the external reviewer's log-cited findings are authoritative. The self-assessment's uncited claims are not.
-
-5. **Merge into the final report.** The final postmortem includes both perspectives. Discrepancies between self-assessment and external review are explicitly noted — they are themselves a finding.
-
-**Precedence rule:** External reviewer findings backed by log evidence override self-assessment claims backed only by memory. A gate "remembered" as having fired but absent from the log did not fire.
-
----
-
-## Batch Analysis Protocol
-
-To run postmortems on older sessions that were never reviewed:
-
-```bash
-# List all sessions, find those without an external postmortem
-for dir in ~/.copilot/session-state/*/; do
-  session_id=$(basename "$dir")
-  if [ ! -f "$dir/postmortem-external.md" ] && [ -f "$dir/events.jsonl" ]; then
-    echo "$session_id"
-  fi
-done
-```
-
-Dispatch up to 4 reviewer subagents in parallel, each pointed at a different `events.jsonl`. Use `postmortem-reviewer.md` for each. Collect results as they complete.
-
-**Priority:**
-1. Sessions with `postmortem.md` but no external review — direct comparison (highest value)
-2. Sessions with `plan.md` but no postmortem — structured work, no retrospective
-3. Sessions with only checkpoints — lower priority
-
-**Batch patterns:** 2+ sessions with the same failure = STRONG action item. Single-session = note only; confirm before acting.
-
----
-
 ## The 5-Part Blameless Postmortem Structure
-
-Work through every part. Do not skip a section because the session "seemed fine."
 
 ### Part 1: Timeline
 
-Reconstruct the session in chronological order. Focus on **decision points** — moments where the agent chose a path. Each entry: what happened, what was the agent's stated reason, what was the actual situation.
-
-```
-HH:MM - [Action taken] — [Stated reason if given] — [Observation]
-```
-
-Do not editorialize in the timeline. Record events.
+Reconstruct the session in chronological order.
 
 ### Part 2: Root Cause
 
-For each failure or near-miss in the timeline, identify the **underlying cause**. Not the proximate cause ("the agent wrote code without a test") but the root cause ("no gate in the session-start checklist enforced TDD before the first `edit` call in this task type").
-
-Use "5 Whys" for each failure:
-```
-Why did X happen?
-  Because Y
-Why did Y happen?
-  Because Z
-...until you reach a system/gate gap, not a character judgment
-```
+For each failure or near-miss in the timeline, identify the **underlying cause**.
 
 ### Part 3: Contributing Factors
 
-What conditions made the root cause more likely? These are not root causes — they are the environment that allowed the root cause to surface.
-
-Examples:
-- Ambiguous requirements that weren't clarified at session start
-- Missing rationalization table entry for a specific excuse pattern
-- Skill that was required but not in the auto-load table
-- Context pressure (long session, many files in flight)
+What conditions made the root cause more likely?
 
 ### Part 4: What Went Well
 
-Name the things that worked — gates that fired correctly, skills that were loaded proactively, subagents that were dispatched when required. This is not a consolation section — it identifies which gates are reliable and MUST be preserved.
+Name the things that worked — gates that fired correctly, skills that were loaded proactively, subagents that were dispatched when required.
 
 ### Part 4b: Where We Got Lucky
 
 This section is separate from "What Went Well" and is the most commonly omitted part of a postmortem.
 
-"Lucky" means: the correct outcome was produced, but not because of a reliable process. The difference:
-
-| What Went Well | Where We Got Lucky |
-|---|---|
-| Gate fired → outcome correct | Gate did not fire → outcome happened to be correct anyway |
-| Plan was followed → no rework | Plan wasn't followed → user didn't notice |
-| Test caught the regression | Test didn't exist → no regression this time |
-
-"Got lucky" items are highest-priority action items. A system that produces correct outcomes by luck is not reliable — the next session the luck will not hold. Name each lucky path and identify the gate that would have caught it if the luck had run out.
-
 ### Part 4c: User Prompt Quality Review
 
-This section is not optional and is not softened to avoid conflict. Poor prompts create conditions that make agent failure more likely — finding those patterns serves both parties.
-
-**The blameless principle applies here too.** Prompt quality review is about prompt patterns, not the user's judgment or intelligence. The same person who writes excellent prompts on Tuesday writes ambiguous ones on Friday under deadline pressure. The goal is to name the pattern so future sessions don't repeat it.
-
-**What to evaluate:**
-
-| Pattern | What it looks like | Why it matters |
-|---|---|---|
-| Multi-part prompt with no priority order | A single message with 8–12 separate instructions | Agent must guess what matters most; important items get buried or dropped |
-| Approval mid-execution | "yes, proceed" or "I was adding commentary" while the agent was already acting | Creates ambiguous ownership of the direction — what was approved, what wasn't? |
-| Scope addition after implementation starts | "also add..." after a plan has been confirmed | Forces replanning mid-execution; earlier work may be invalidated |
-| Implicit requirements treated as obvious | Requirements not stated because "it's obvious" | Agent optimizes for the stated goal, not the unstated one |
-| Contradictory instructions in the same message | Two rules that cannot both be followed | Agent picks one silently; user is surprised by the choice |
-| "Just do it" for a task needing design review | "just implement X directly" for a multi-subsystem change | Bypasses brainstorming gate by framing the task as simple |
-| Moving goalposts without acknowledgment | Changing requirements mid-session without noting what changed | Agent may be building toward an invalidated target without knowing it |
-
-**What the review MUST produce:**
-
-For each pattern found, cite the specific message or exchange where it occurred. Name what the effect was (lost work, wrong direction, wasted subagent runs). Give one concrete recommendation for how that type of prompt could be written differently next time.
-
-Do not soften findings. A prompt that cost three subagent runs and a revert deserves to be called that, with the example quoted.
-
-**Format:**
-
-```
-#### Prompt Feedback
-
-**Pattern found:** [name from table above]
-**Example (quoted or paraphrased):** "[the prompt or relevant portion]"
-**Effect:** [what it caused — misdirection, wasted agents, ambiguity not caught until late]
-**Recommendation:** [one specific, actionable change for future prompts of this type]
-```
-
-If no patterns are found after genuine review, state that explicitly with evidence. Do not omit this section — an empty section with "no issues found" and supporting evidence is the correct output when prompts were clean.
-
----
+This section is not optional and is not softened to avoid conflict.
 
 ### Part 5: Action Items
 
-For every root cause and contributing factor, one concrete action item. Each must be:
-- **Specific** — names the exact skill file and section to update
-- **Triggerable** — describes exactly what MUST happen differently
-- **Owned** — states which skill or gate owns the change
+For every root cause and contributing factor, one concrete action item.
 
-**Dan Milstein Classification (apply to every action item):**
-
-| Strength | Type | Why |
-|----------|------|-----|
-| ✅ STRONG | Gate/system change — a structural change that makes the default behavior correct | Changes the system; no willpower required |
-| ✅ STRONG | Rationalization table addition — explicitly names and counters the excuse used | Counters the specific thought pattern before it fires |
-| ✅ STRONG | Red Flag → STOP addition — a new trigger phrase added to the checklist | Mechanical: fires on recognition, not intent |
-| ❌ WEAK | Behavior-change item — "be more careful about X", "remember to check Y" | Requires willpower on every occurrence; degrades under pressure |
-| ❌ WEAK | Vague skill update — "improve the planning section" | Cannot be applied mechanically; produces inconsistent results |
-
-**Required:** Every action item must be STRONG classification. If you can only produce a WEAK item, ask: "What structural change would make this mistake impossible to make, rather than just less likely?"
-
-| # | Root Cause / Factor | Action Item | Strength | Target File |
-|---|---------------------|-------------|----------|-------------|
-| 1 | [Root cause] | Add "[specific text]" to [section] | ✅/❌ | [skill file] |
-
-No vague items. "Be more careful" is not an action item. "Add the phrase 'X' to the rationalization table in execution Phase 2 under excuse 'Y'" is.
-
----
-
-## Write Gate — Required Before Postmortem Is Complete
-
-**Before announcing the postmortem complete**, the final report MUST be written to disk:
-
-```bash
-ls [SESSION_ID]/postmortem.md
-```
-
-If the file does not exist, use `create` to write it now.
-If the file already exists (multi-task session), use `edit` to append a new `## Phase N: [Task Name]` section — never create a second postmortem file. A postmortem that exists only in the message stream is not a postmortem.
-
----
-
-## Iron Law Compliance Check
-
-Run every item before generating the report:
-
-| Law | Followed | Evidence | Notes |
-|-----|----------|----------|-------|
-| TDD (no prod code without test) | ✅/❌/N/A | [what proves this] | |
-| Verification before completion | ✅/❌/N/A | [what proves this] | |
-| Root cause before fixes | ✅/❌/N/A | [what proves this] | |
-| Conventional commits | ✅/❌/N/A | [what proves this] | |
-| Skills loaded before acting | ✅/❌/N/A | [what proves this] | |
-| Commitments kept or acknowledged | ✅/❌/N/A | [what proves this] | |
-
-✓ All followed → note compliance in report
-✗ Any violated → verdict is SYSTEMIC ISSUE for the violated law — document in action items
-
----
-
-## Postmortem Report Format
-
-For the full report template (Summary, Timeline, Root Cause Analysis, Contributing Factors, What Went Well, Where We Got Lucky, External Reviewer Findings, Prompt Feedback, Action Items, Iron Law Compliance, Verdict) and verdict definitions (HEALTHY / NEEDS IMPROVEMENT / SYSTEMIC ISSUE), see `references/POSTMORTEM_STRUCTURE.md`.
+See `references/POSTMORTEM_STRUCTURE.md` for full detail and `references/BATCH_ANALYSIS.md` for batch commands.
 
 ---
 
@@ -306,3 +103,4 @@ Three or more of the above = SYSTEMIC ISSUE. Relevant skills need immediate rati
 - `execution` — iron laws this skill checks for compliance
 - `verification-before-completion` — the gate this skill checks was applied correctly
 - `skill-reviewer` — if skill gaps are found, dispatch skill-reviewer to verify the updated skill is complete
+

--- a/.github/skills/session-postmortem/SKILL.md
+++ b/.github/skills/session-postmortem/SKILL.md
@@ -20,6 +20,8 @@ YOU MUST examine the session for rationalization patterns. A clean outcome does 
 
 ## BEFORE PROCEEDING — Postmortem Gate
 
+Before starting the postmortem analysis:
+
 1. The session being analyzed has completed — no further work is planned for that session.
 2. The session's `events.jsonl` log is accessible at `[SESSION_ID]/events.jsonl`.
 3. You are running as an EXTERNAL reviewer — you have not been the agent in the session being analyzed.

--- a/.github/skills/session-postmortem/SKILL.md
+++ b/.github/skills/session-postmortem/SKILL.md
@@ -33,6 +33,7 @@ Before starting the postmortem analysis:
 
 ## The 5-Part Blameless Postmortem Structure
 
+<!-- Keep part names in sync with POSTMORTEM_STRUCTURE.md -->
 ### Part 1: Timeline
 
 Reconstruct the session in chronological order.

--- a/.github/skills/session-postmortem/references/BATCH_ANALYSIS.md
+++ b/.github/skills/session-postmortem/references/BATCH_ANALYSIS.md
@@ -1,0 +1,22 @@
+# Batch Analysis
+
+To run postmortems on older sessions that were never reviewed:
+
+```bash
+# List all sessions, find those without an external postmortem
+for dir in ~/.copilot/session-state/*/; do
+  session_id=$(basename "$dir")
+  if [ ! -f "$dir/postmortem-external.md" ] && [ -f "$dir/events.jsonl" ]; then
+    echo "$session_id"
+  fi
+done
+```
+
+Dispatch up to 4 reviewer subagents in parallel, each pointed at a different `events.jsonl`. Use `postmortem-reviewer.md` for each. Collect results as they complete.
+
+**Priority:**
+1. Sessions with `postmortem.md` but no external review — direct comparison (highest value)
+2. Sessions with `plan.md` but no postmortem — structured work, no retrospective
+3. Sessions with only checkpoints — lower priority
+
+**Batch patterns:** 2+ sessions with the same failure = STRONG action item. Single-session = note only; confirm before acting.

--- a/.github/skills/session-postmortem/references/POSTMORTEM_STRUCTURE.md
+++ b/.github/skills/session-postmortem/references/POSTMORTEM_STRUCTURE.md
@@ -53,3 +53,203 @@ Canonical template and verdict definitions for session postmortem reports.
 - **HEALTHY** — iron laws followed, no repeated failure modes, skills loaded proactively
 - **NEEDS IMPROVEMENT** — one or two isolated lapses; skill updates would prevent recurrence
 - **SYSTEMIC ISSUE** — same failure mode appeared multiple times, or the agent bypassed an iron law and delivered a result anyway
+
+---
+
+## The Blameless Principle
+
+This postmortem is about **decisions and systems**, not character. Every failure is a decision that could be better-gated or better-informed. The language in the report must reflect this.
+
+| Blameful (forbidden) | Blameless (required) |
+|----------------------|---------------------|
+| "The agent was careless" | "The planning gate was not applied before code was written" |
+| "The agent didn't follow the rules" | "The rationalization table did not cover this excuse pattern" |
+| "The agent got lucky" | "The process produced a correct outcome by path rather than by gate" |
+| "The agent lied" | "The confidence vocabulary gate was not active for this claim type" |
+
+The goal is not to evaluate the agent — it is to find the gaps in the system that allowed the failure to occur undetected. A gap found is a skill improvement waiting to be written.
+
+---
+
+## Difference From Self-Evaluation
+
+| Skill | Who runs it | When | What it analyzes |
+|-------|-------------|------|-----------------|
+| `self-evaluation` | The agent itself | At the end of its own session | Outcomes, lessons, skill updates |
+| `session-postmortem` | A different agent or human reviewer | After a session closes | Agent *behavior* patterns during the session |
+
+Self-evaluation captures what was learned. Session postmortem finds where the agent rationalized, bypassed laws, or got lucky.
+
+---
+
+## External Reviewer Protocol (Required)
+
+A self-assessment cannot find what the agent rationalized away. **An external reviewer reads the raw event log cold — no session memory, no emotional investment in the outcome.** This is not optional. A postmortem with only self-assessment is incomplete.
+
+### Setup
+
+Derive the paths for the session being reviewed from your project's session management conventions. For Particle-Viewer path conventions, see `references/PV_SESSION_PATHS.md`.
+
+### Protocol
+
+1. **Dispatch the external reviewer subagent** using `.github/agents/postmortem-reviewer.md` with the above paths filled in. The reviewer reads `events.jsonl` directly — no pre-export needed.
+
+2. **Run self-assessment in parallel** (the main agent does Parts 1–5 from memory while the reviewer works). **INDEPENDENCE GATE: Write the self-assessment FROM MEMORY ONLY — do NOT read `events.jsonl`, checkpoints, `plan.md`, or any session artifact before writing `postmortem.md`. `postmortem.md` MUST be created on disk before you read any source data. Only after the file exists may you read session data or wait for the external review to complete. Reading session artifacts first means the self-assessment is a log summary, not independent assessment. Do NOT announce yourself as "external reviewer" or "cold read" in your own context — that role belongs exclusively to the dispatched subagent.**
+
+   **If `postmortem.md` already exists** (multi-phase session): do NOT read its content to find an append anchor. Append with `## Phase N: [Task Name]` — construct a unique section heading without reading the existing file. "Finding the anchor" is not an exemption from the independence gate.
+
+3. **Wait for the reviewer to complete.** Read its output from `postmortem-external.md`. **The only permissible action between dispatching the external reviewer and `read_agent` returning is polling (`read_agent`). Do NOT announce a verdict, summarize findings, or output any assessment until `read_agent` returns. A verdict announced before the external review completes will be based on incomplete information and may directly contradict the reviewer's log-cited findings.**
+
+4. **Reconcile.** Where the external reviewer and self-assessment agree: note the convergence. Where they conflict: the external reviewer's log-cited findings are authoritative. The self-assessment's uncited claims are not.
+
+5. **Merge into the final report.** The final postmortem includes both perspectives. Discrepancies between self-assessment and external review are explicitly noted — they are themselves a finding.
+
+**Precedence rule:** External reviewer findings backed by log evidence override self-assessment claims backed only by memory. A gate "remembered" as having fired but absent from the log did not fire.
+
+---
+
+## Full 5-Part Structure
+
+### Part 1: Timeline
+
+Reconstruct the session in chronological order. Focus on **decision points** — moments where the agent chose a path. Each entry: what happened, what was the agent's stated reason, what was the actual situation.
+
+```
+HH:MM - [Action taken] — [Stated reason if given] — [Observation]
+```
+
+Do not editorialize in the timeline. Record events.
+
+### Part 2: Root Cause
+
+For each failure or near-miss in the timeline, identify the **underlying cause**. Not the proximate cause ("the agent wrote code without a test") but the root cause ("no gate in the session-start checklist enforced TDD before the first `edit` call in this task type").
+
+Use "5 Whys" for each failure:
+```
+Why did X happen?
+  Because Y
+Why did Y happen?
+  Because Z
+...until you reach a system/gate gap, not a character judgment
+```
+
+### Part 3: Contributing Factors
+
+What conditions made the root cause more likely? These are not root causes — they are the environment that allowed the root cause to surface.
+
+Examples:
+- Ambiguous requirements that weren't clarified at session start
+- Missing rationalization table entry for a specific excuse pattern
+- Skill that was required but not in the auto-load table
+- Context pressure (long session, many files in flight)
+
+### Part 4: What Went Well
+
+Name the things that worked — gates that fired correctly, skills that were loaded proactively, subagents that were dispatched when required. This is not a consolation section — it identifies which gates are reliable and MUST be preserved.
+
+### Part 4b: Where We Got Lucky
+
+This section is separate from "What Went Well" and is the most commonly omitted part of a postmortem.
+
+"Lucky" means: the correct outcome was produced, but not because of a reliable process. The difference:
+
+| What Went Well | Where We Got Lucky |
+|---|---|
+| Gate fired → outcome correct | Gate did not fire → outcome happened to be correct anyway |
+| Plan was followed → no rework | Plan wasn't followed → user didn't notice |
+| Test caught the regression | Test didn't exist → no regression this time |
+
+"Got lucky" items are highest-priority action items. A system that produces correct outcomes by luck is not reliable — the next session the luck will not hold. Name each lucky path and identify the gate that would have caught it if the luck had run out.
+
+### Part 4c: User Prompt Quality Review
+
+This section is not optional and is not softened to avoid conflict. Poor prompts create conditions that make agent failure more likely — finding those patterns serves both parties.
+
+**The blameless principle applies here too.** Prompt quality review is about prompt patterns, not the user's judgment or intelligence. The same person who writes excellent prompts on Tuesday writes ambiguous ones on Friday under deadline pressure. The goal is to name the pattern so future sessions don't repeat it.
+
+**What to evaluate:**
+
+| Pattern | What it looks like | Why it matters |
+|---|---|---|
+| Multi-part prompt with no priority order | A single message with 8–12 separate instructions | Agent must guess what matters most; important items get buried or dropped |
+| Approval mid-execution | "yes, proceed" or "I was adding commentary" while the agent was already acting | Creates ambiguous ownership of the direction — what was approved, what wasn't? |
+| Scope addition after implementation starts | "also add..." after a plan has been confirmed | Forces replanning mid-execution; earlier work may be invalidated |
+| Implicit requirements treated as obvious | Requirements not stated because "it's obvious" | Agent optimizes for the stated goal, not the unstated one |
+| Contradictory instructions in the same message | Two rules that cannot both be followed | Agent picks one silently; user is surprised by the choice |
+| "Just do it" for a task needing design review | "just implement X directly" for a multi-subsystem change | Bypasses brainstorming gate by framing the task as simple |
+| Moving goalposts without acknowledgment | Changing requirements mid-session without noting what changed | Agent may be building toward an invalidated target without knowing it |
+
+**What the review MUST produce:**
+
+For each pattern found, cite the specific message or exchange where it occurred. Name what the effect was (lost work, wrong direction, wasted subagent runs). Give one concrete recommendation for how that type of prompt could be written differently next time.
+
+Do not soften findings. A prompt that cost three subagent runs and a revert deserves to be called that, with the example quoted.
+
+**Format:**
+
+```
+#### Prompt Feedback
+
+**Pattern found:** [name from table above]
+**Example (quoted or paraphrased):** "[the prompt or relevant portion]"
+**Effect:** [what it caused — misdirection, wasted agents, ambiguity not caught until late]
+**Recommendation:** [one specific, actionable change for future prompts of this type]
+```
+
+If no patterns are found after genuine review, state that explicitly with evidence. Do not omit this section — an empty section with "no issues found" and supporting evidence is the correct output when prompts were clean.
+
+### Part 5: Action Items
+
+For every root cause and contributing factor, one concrete action item. Each must be:
+- **Specific** — names the exact skill file and section to update
+- **Triggerable** — describes exactly what MUST happen differently
+- **Owned** — states which skill or gate owns the change
+
+**Dan Milstein Classification (apply to every action item):**
+
+| Strength | Type | Why |
+|----------|------|-----|
+| ✅ STRONG | Gate/system change — a structural change that makes the default behavior correct | Changes the system; no willpower required |
+| ✅ STRONG | Rationalization table addition — explicitly names and counters the excuse used | Counters the specific thought pattern before it fires |
+| ✅ STRONG | Red Flag → STOP addition — a new trigger phrase added to the checklist | Mechanical: fires on recognition, not intent |
+| ❌ WEAK | Behavior-change item — "be more careful about X", "remember to check Y" | Requires willpower on every occurrence; degrades under pressure |
+| ❌ WEAK | Vague skill update — "improve the planning section" | Cannot be applied mechanically; produces inconsistent results |
+
+**Required:** Every action item must be STRONG classification. If you can only produce a WEAK item, ask: "What structural change would make this mistake impossible to make, rather than just less likely?"
+
+| # | Root Cause / Factor | Action Item | Strength | Target File |
+|---|---------------------|-------------|----------|-------------|
+| 1 | [Root cause] | Add "[specific text]" to [section] | ✅/❌ | [skill file] |
+
+No vague items. "Be more careful" is not an action item. "Add the phrase 'X' to the rationalization table in execution Phase 2 under excuse 'Y'" is.
+
+---
+
+## Write Gate — Required Before Postmortem Is Complete
+
+**Before announcing the postmortem complete**, the final report MUST be written to disk:
+
+```bash
+ls [SESSION_ID]/postmortem.md
+```
+
+If the file does not exist, use `create` to write it now.
+If the file already exists (multi-task session), use `edit` to append a new `## Phase N: [Task Name]` section — never create a second postmortem file. A postmortem that exists only in the message stream is not a postmortem.
+
+---
+
+## Iron Law Compliance Check
+
+Run every item before generating the report:
+
+| Law | Followed | Evidence | Notes |
+|-----|----------|----------|-------|
+| TDD (no prod code without test) | ✅/❌/N/A | [what proves this] | |
+| Verification before completion | ✅/❌/N/A | [what proves this] | |
+| Root cause before fixes | ✅/❌/N/A | [what proves this] | |
+| Conventional commits | ✅/❌/N/A | [what proves this] | |
+| Skills loaded before acting | ✅/❌/N/A | [what proves this] | |
+| Commitments kept or acknowledged | ✅/❌/N/A | [what proves this] | |
+
+✓ All followed → note compliance in report
+✗ Any violated → verdict is SYSTEMIC ISSUE for the violated law — document in action items

--- a/.github/skills/session-postmortem/references/POSTMORTEM_STRUCTURE.md
+++ b/.github/skills/session-postmortem/references/POSTMORTEM_STRUCTURE.md
@@ -41,7 +41,7 @@ Canonical template and verdict definitions for session postmortem reports.
 |---|---------------------|-------------|-------------|
 
 ### Iron Law Compliance
-[Insert the Iron Law Compliance Check table from session-postmortem SKILL.md]
+[Insert the Iron Law Compliance Check table from `references/POSTMORTEM_STRUCTURE.md`]
 
 ### Verdict: HEALTHY / NEEDS IMPROVEMENT / SYSTEMIC ISSUE
 ```

--- a/.github/skills/session-postmortem/references/POSTMORTEM_STRUCTURE.md
+++ b/.github/skills/session-postmortem/references/POSTMORTEM_STRUCTURE.md
@@ -108,7 +108,9 @@ Derive the paths for the session being reviewed from your project's session mana
 
 ---
 
-## Full 5-Part Structure
+## The 5-Part Blameless Postmortem Structure
+
+Work through every part. Do not skip a section because the session "seemed fine."
 
 ### Part 1: Timeline
 

--- a/.github/skills/session-postmortem/references/POSTMORTEM_STRUCTURE.md
+++ b/.github/skills/session-postmortem/references/POSTMORTEM_STRUCTURE.md
@@ -41,7 +41,7 @@ Canonical template and verdict definitions for session postmortem reports.
 |---|---------------------|-------------|-------------|
 
 ### Iron Law Compliance
-[Insert the Iron Law Compliance Check table from `references/POSTMORTEM_STRUCTURE.md`]
+[Insert the Iron Law Compliance Check table from the "## Iron Law Compliance Check" section below]
 
 ### Verdict: HEALTHY / NEEDS IMPROVEMENT / SYSTEMIC ISSUE
 ```

--- a/.github/skills/subagent-driven-development/SKILL.md
+++ b/.github/skills/subagent-driven-development/SKILL.md
@@ -230,7 +230,7 @@ See `references/MODEL_SELECTION.md` for model tier table and concurrency rules.
 ## Delegation Quality Rules
 
 - **One clear objective per subagent** — no multi-part briefs
-- **Assign Problems Not Tasks:** delegate the outcome, not the steps — See the `writing-plans` skill — 'Assign Problems Not Tasks' principle.
+- **Assign Problems Not Tasks:** delegate the outcome, not the steps — see the `writing-plans` skill — 'Assign Problems Not Tasks' principle.
 - **State the return format explicitly** — tell it exactly what to give back
 - **Provide complete context** — subagents are stateless
 - **Fresh context per task** — never share session history; it contaminates the subagent's search

--- a/.github/skills/subagent-driven-development/SKILL.md
+++ b/.github/skills/subagent-driven-development/SKILL.md
@@ -205,81 +205,32 @@ Stage 2: Code Quality Review        ← ONLY after Stage 1 passes (code-quality-
 
 ### Stage 1: Spec Compliance Review
 
-**Question:** Does the implementation do what the spec/requirements asked?
-
-Use `.github/agents/spec-compliance-reviewer.md`. Provide:
-- Full requirements / acceptance criteria for the todo
-- Full diff or file contents of the implementation
-
-If Stage 1 returns GAPS: implementer fixes gaps. Re-run Stage 1 before proceeding.
+Use `spec-compliance-reviewer.md` with full requirements and the implementation diff; if GAPS are returned, implementer fixes and Stage 1 re-runs before proceeding.
 
 ### Stage 2: Code Quality Review
 
-**Question:** Is the implementation clean, maintainable, and correct?
+Use `code-quality-reviewer.md` — one agent per file changed; if REQUEST CHANGES, implementer fixes and Stage 2 re-runs before proceeding.
 
-Use `.github/agents/code-quality-reviewer.md` — 1 agent per file changed.
-
-If Stage 2 returns REQUEST CHANGES: implementer fixes. Re-run Stage 2 before proceeding.
+See `references/REVIEW_PROTOCOL.md` for full protocol.
 
 ---
 
 ## Git Worktrees for Parallel Work
 
-When a subagent needs to **modify files** (not just read), give it a worktree:
-
-```bash
-# Create worktree
-git worktree add .worktrees/agent-task-name -b feat/agent-task-name
-
-# Verify .worktrees is gitignored (BEFORE creating)
-git check-ignore -q .worktrees || echo "ADD .worktrees TO .gitignore FIRST"
-
-# Pass this path as working directory in the subagent prompt
-
-# After subagent completes — review its diff
-git -C .worktrees/agent-task-name diff main
-
-# Merge and clean up
-git worktree remove .worktrees/agent-task-name
-```
-
-**Directory selection priority:** `.worktrees/` → `worktrees/` → ask user
-**Safety gate:** Run `git check-ignore -q .worktrees` before creating. If not ignored, add to `.gitignore` immediately — do not skip.
+See the `using-git-worktrees` skill for full worktree lifecycle, commands, and safety gates.
 
 ---
 
 ## Model Selection
 
-Match model tier to task complexity. Instructions must be written for GPT-4.1 baseline regardless of selected tier.
-
-**Model preference priority — check in this order before every agent dispatch:**
-
-1. **Stored memory override (highest):** Check stored memories for a user-specified model preference. If found, apply that tier to ALL agents in this batch — it overrides the table below.
-2. **Tier table (default):** If no stored preference, use the task-type table below.
-3. **Session default (fallback):** If neither applies, use the current session default.
-
-If the user states a model preference in the current session, store it as a memory fact immediately so it persists.
-
-| Task type | Default tier |
-|-----------|-------------|
-| Mechanical: grep, rename, format, one-function change | Standard |
-| Research: read files, summarize patterns, compare approaches | Standard |
-| Implementation: multi-file, design judgment | Standard |
-| Review: spec compliance, code quality, architecture | Standard |
-| Architecture design, security, final review | Premium |
-
-**Using Premium for non-architecture tasks:** State the reasoning before dispatching. Example: "Dispatching Premium for this review because the change touches 3 layer boundaries." Do not dispatch Premium silently for mechanical work.
-
-**Concurrency:** Copilot Enterprise accounts have no practical agent concurrency limit. Dispatch as many parallel agents as the task warrants. Standard accounts: verify your limit before parallelizing.
-
-**For parallel read-only research:** Use `dispatching-parallel-agents` skill.
+See `references/MODEL_SELECTION.md` for model tier table and concurrency rules.
 
 ---
 
 ## Delegation Quality Rules
 
 - **One clear objective per subagent** — no multi-part briefs
-- **Assign Problems Not Tasks:** delegate the outcome, not the steps — see `writing-plans/references/SIMPLICITY_PRINCIPLES.md#assign-problems-not-tasks`
+- **Assign Problems Not Tasks:** delegate the outcome, not the steps — See the `writing-plans` skill — 'Assign Problems Not Tasks' principle.
 - **State the return format explicitly** — tell it exactly what to give back
 - **Provide complete context** — subagents are stateless
 - **Fresh context per task** — never share session history; it contaminates the subagent's search

--- a/.github/skills/subagent-driven-development/references/MODEL_SELECTION.md
+++ b/.github/skills/subagent-driven-development/references/MODEL_SELECTION.md
@@ -1,0 +1,25 @@
+# Model Selection
+
+Match model tier to task complexity. Instructions must be written for GPT-4.1 baseline regardless of selected tier.
+
+**Model preference priority — check in this order before every agent dispatch:**
+
+1. **Stored memory override (highest):** Check stored memories for a user-specified model preference. If found, apply that tier to ALL agents in this batch — it overrides the table below.
+2. **Tier table (default):** If no stored preference, use the task-type table below.
+3. **Session default (fallback):** If neither applies, use the current session default.
+
+If the user states a model preference in the current session, store it as a memory fact immediately so it persists.
+
+| Task type | Default tier |
+|-----------|-------------|
+| Mechanical: grep, rename, format, one-function change | Standard |
+| Research: read files, summarize patterns, compare approaches | Standard |
+| Implementation: multi-file, design judgment | Standard |
+| Review: spec compliance, code quality, architecture | Standard |
+| Architecture design, security, final review | Premium |
+
+**Using Premium for non-architecture tasks:** State the reasoning before dispatching. Example: "Dispatching Premium for this review because the change touches 3 layer boundaries." Do not dispatch Premium silently for mechanical work.
+
+**Concurrency:** Copilot Enterprise accounts have no practical agent concurrency limit. Dispatch as many parallel agents as the task warrants. Standard accounts: verify your limit before parallelizing.
+
+**For parallel read-only research:** Use `dispatching-parallel-agents` skill.

--- a/.github/skills/subagent-driven-development/references/REVIEW_PROTOCOL.md
+++ b/.github/skills/subagent-driven-development/references/REVIEW_PROTOCOL.md
@@ -1,0 +1,19 @@
+# 2-Stage Review Protocol — Full Details
+
+## Stage 1: Spec Compliance Review
+
+**Question:** Does the implementation do what the spec/requirements asked?
+
+Use `.github/agents/spec-compliance-reviewer.md`. Provide:
+- Full requirements / acceptance criteria for the todo
+- Full diff or file contents of the implementation
+
+If Stage 1 returns GAPS: implementer fixes gaps. Re-run Stage 1 before proceeding.
+
+## Stage 2: Code Quality Review
+
+**Question:** Is the implementation clean, maintainable, and correct?
+
+Use `.github/agents/code-quality-reviewer.md` — 1 agent per file changed.
+
+If Stage 2 returns REQUEST CHANGES: implementer fixes. Re-run Stage 2 before proceeding.

--- a/.github/skills/testing/SKILL.md
+++ b/.github/skills/testing/SKILL.md
@@ -10,8 +10,6 @@ description: Use when writing or reviewing any test for Particle-Viewer.
 NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST
 ```
 
-Violating the letter of this rule is violating the spirit of this rule.
-
 YOU MUST write a failing test before writing any production code. No exceptions.
 
 Write the test. Watch it fail. THEN write code.
@@ -26,63 +24,20 @@ If you wrote code before the test: **Delete it. Start over.** No exceptions.
 
 ---
 
-# Instructions for Agent
-
-## How This Skill is Invoked
-
-In VS Code, users will activate this skill by:
-- Typing `@workspace /testing [description]` in Copilot Chat
-- Or asking: "Write a test for [feature]", "Add visual regression tests", "Review my test code"
-
-When activated, write tests that strictly follow the project's testing standards.
-
----
-
-## Core Approach: Standards-First Testing
-
-**Every test MUST follow the Arrange-Act-Assert (AAA) pattern with all three phases as separate sections.**
-
-Before writing any test, **load and review** [references/TESTING_EXAMPLES.md](references/TESTING_EXAMPLES.md) for concrete examples of correct and incorrect patterns.
-
----
-
 ## TDD Cycle
 
 **RED → GREEN → REFACTOR. In that order. Every time.**
 
-```
-RED: Write one failing test
-  - Use TEST() or TEST_F() macro
-  - Name: UnitName_Condition_ExpectedResult
-  - Test one behavior only
-  - Run it: ./build/tests/ParticleViewerTests --gtest_filter=Suite.TestName
-  - YOU MUST SEE THE TEST FAIL. Observe the failure message. Confirm it fails
-    for the reason you expect — not due to a compile error or wrong test setup.
-  - If it passes immediately: you are testing existing behavior OR the test is wrong.
-    Fix the test before writing any production code.
+- **RED:** Write one failing test. Name: `UnitName_Condition_ExpectedResult`. YOU MUST SEE IT FAIL — confirm it fails for the expected reason, not a compile error. If it passes immediately: the test is wrong. Fix it before writing production code.
+- **GREEN:** Write the simplest code to make it pass. ALL tests must pass (not just the new one).
+- **REFACTOR:** Remove duplication, improve names. Never add behavior. Tests stay green throughout.
 
-GREEN: Write minimal implementation
-  - Simplest code to make the test pass
-  - No extra features, no "while I'm here" refactoring
-  - Run the full suite: ./build/tests/ParticleViewerTests
-  - ALL tests must pass (not just the new one)
-  - GREEN = permission to refactor. NOT permission to stop. Proceed to REFACTOR.
-
-REFACTOR: Clean up
-  - Remove duplication
-  - Improve names
-  - Never add behavior during refactor
-  - Tests must stay green throughout
-  - Apply the Behavior Preservation Gate: run tests before each change, run after each change
-```
-
-**Agile Alarm Bell:** "Let's refactor without writing tests first" is the most dangerous phrase pair in software. Refactoring without a test suite to hold behavior constant is not refactoring — it is reckless restructuring. Stop. Write characterization tests first. Then refactor.
+For PV test runner commands, see `references/PV_TEST_CONVENTIONS.md`.
 
 ---
 
 ## Step 1: Determine Test Type
 
-Classify the test before writing it:
 - **Unit test** — single class/function in isolation → `tests/core/`
 - **Integration test** — component interactions → `tests/integration/`
 - **Visual regression test** — pixel comparison → load `visual-regression-testing` skill
@@ -92,23 +47,9 @@ Classify the test before writing it:
 
 ## Step 2: Write Tests Following AAA Pattern
 
-### The Three Phases (ALWAYS separate)
+Every test MUST have three distinct comment sections: `// Arrange`, `// Act`, `// Assert`.
 
-Every test MUST have three distinct comment sections:
-
-```cpp
-TEST(SuiteName, MethodName_Condition_ExpectedResult)
-{
-    // Arrange
-    // Set up test preconditions, create objects, define expected values
-
-    // Act
-    // Execute the single operation being tested
-
-    // Assert
-    // Verify the outcome
-}
-```
+See `references/TESTING_EXAMPLES.md` for code examples and advanced patterns.
 
 ### Critical Rules
 
@@ -124,65 +65,10 @@ Use format: `UnitName_StateUnderTest_ExpectedResult`
 
 Examples:
 - `MoveForward_IncreasesZPosition`
-- `Compare_IdenticalImages_ReturnsMatch`
-- `ParsePPM_InvalidFile_ReturnsEmptyData`
 
----
+See `references/TESTING_EXAMPLES.md` for PV naming examples.
 
-## Step 3: Choose the Right Test Pattern
-
-### Unit Tests (tests/core/)
-
-Test a single class method in isolation. Use mock implementations for interface dependencies.
-
-For Particle-Viewer unit and integration test examples (Camera, SettingsIO), see `references/PV_TEST_CONVENTIONS.md`.
-
-### Integration Tests (tests/integration/)
-
-Test component interactions. May involve multiple classes.
-
-For Particle-Viewer integration test examples, see `references/PV_TEST_CONVENTIONS.md`.
-
-### Visual Regression Tests → see `visual-regression-testing` skill
-
----
-
-## Test Double Taxonomy
-
-Use the **least sophisticated double** that answers your question. Reaching for `EXPECT_CALL` when a stub suffices is over-engineering.
-
-| Double | Behavior | Verifies Calls? | When to Use |
-|--------|----------|-----------------|-------------|
-| **Stub** | No-op methods; returns null/zero/false | No | You need `IOpenGLContext` to not crash; you don't care what it called |
-| **Fake** | Returns programmable values via setters | No | You need to control what `glGetError()` returns without interaction verification |
-| **Mock** | Returns values AND verifies call expectations | Yes — test fails if expected calls are not made | You must assert `glDrawArrays` was called exactly once with specific arguments |
-| **Shunt / SelfShunt** | The test fixture itself implements the interface | Inspected in teardown | Lowest setup overhead when the fixture plays both collaborator and verifier |
-
-**Google Mock mapping:** Stub → subclass returning constants. Fake → subclass with setters. Mock → `MOCK_METHOD` + `EXPECT_CALL` + `Times()`. Shunt → `TEST_F` fixture inherits from the interface.
-
-**Key principle:** Mock the *role* (interface), not the concrete object. `MockOpenGLContext` mocks `IOpenGLContext` — stable across implementation changes.
-
-**When NOT to use Google Mock:** If the question is "does this run without crashing?", a stub suffices. Only use `EXPECT_CALL` when the interaction itself is the behavior under test.
-
----
-
-## Step 4: Apply Test File Organization
-
-### Directory Structure
-
-- `tests/core/` — Unit tests for `src/*.hpp` classes
-- `tests/integration/` — Multi-component tests
-- `tests/testing/` — Tests for test utilities (PixelComparator, Image)
-- `tests/visual-regression/` — Visual regression tests
-- `tests/mocks/` — Mock implementations
-
-### File Naming
-
-Each test file matches its source: `CameraTests.cpp` tests `camera.hpp`.
-
-### Test Ordering
-
-Within a file, order tests: basic → complex, common → edge cases.
+For PV-specific test patterns (Camera, SettingsIO examples), test double taxonomy, file organization, and test size taxonomy, see `references/PV_TEST_CONVENTIONS.md`. For visual regression, see the `visual-regression-testing` skill.
 
 ---
 
@@ -216,10 +102,7 @@ If you catch yourself thinking any of these, STOP and start over with RED:
 - "The visual regression test will cover this"
 - "It's too complex to unit test with MockOpenGL" (MockOpenGL exists for exactly this)
 - "I already manually tested it"
-- "Tests after achieve the same goals"
-- "Just this once" or "This is different because..."
 - Test passes immediately without seeing it fail first
-- "I need to get the implementation right before I know what to test"
 - Fixed a bug without writing a regression test that reproduces it first
 
 **All of these mean: Delete any code written before the test. Start over with RED.**
@@ -235,74 +118,19 @@ If you catch yourself thinking any of these, STOP and start over with RED:
 | "Visual regression test will cover it" | Visual tests are slow and test pixels, not logic. Unit test the logic. |
 | "Too complex to test in isolation" | That's a design signal. Simplify the interface. MockOpenGL is there for GL calls. |
 | "Already manually tested it" | Manual testing is ad-hoc. No record, can't re-run, misses edge cases. |
-| "Tests after achieve the same goals" | Tests-after answer "what does this do?" Tests-first answer "what SHOULD this do?" |
-| "Deleting X hours of work is wasteful" | Sunk cost. Keeping untested code is technical debt. |
 | "TDD slows me down" | TDD is faster than debugging production failures. |
-| "The bug was a one-off, no regression test needed" | One-off bugs recur after the next refactoring. A regression test takes 5 minutes; a re-investigation takes hours. |
-
----
-
-## Key Design Principles (Learned from Review Feedback)
-
-For Particle-Viewer specific test design principles (GL resource cleanup, binary I/O mode, output directory setup, visual resolution, camera positioning, regression test requirements), see `references/PV_TEST_CONVENTIONS.md`.
-
-General principles that apply to any project:
-
-1. **Use production classes in tests.** Do not re-implement production logic in test helpers — tests will drift from production behavior.
-2. **Group related data into POCOs/structs.** When a test has many flat member variables, group them into domain-specific structs. This mirrors the production code pattern.
-3. **Every bug fix requires a regression test.** Write a test that reproduces the bug (fails before the fix). Fix the code. Confirm the test now passes. A bug fixed without a test is a bug scheduled for a return visit.
 
 ---
 
 ## Self-Evaluation
 
-After completing test work, run the `self-evaluation` skill (`.github/skills/self-evaluation/`) to capture any new testing patterns learned during the session.
-
-For mock-related anti-patterns, see [references/testing-anti-patterns.md](references/testing-anti-patterns.md). For test smells across any language, see [references/TEST_SMELLS.md](references/TEST_SMELLS.md).
-
----
-
-## Test Size Taxonomy (SE@G Model)
-
-Apply this taxonomy when classifying tests and deciding where they belong:
-
-| Size | Resource use | Scope | Directory |
-|------|-------------|-------|-----------|
-| **Small** | No I/O, no network, no filesystem, no external processes, no OpenGL context | Single unit in memory | `tests/` root or subdirectory |
-| **Medium** | Localhost I/O permitted (files, sockets), no external services, no real OpenGL | Component interactions, file I/O | `tests/integration/` |
-| **Large** | Real OpenGL context, real GPU, external processes, full system | End-to-end rendering, visual output | `tests/visual-regression/` |
-
-**Classification gate:** Before writing a test, classify it. If a "unit test" uses a real file, it is Medium. If it uses a real OpenGL context, it is Large. Misclassified tests in the wrong directory produce slow/unreliable CI runs.
-
-## The Depended-Upon Behavior Rule
-
-Any behavior that your code **relies upon** must have a test. This applies to:
-- Your own functions (don't assume they work; prove it)
-- Libraries you depend on (test the integration point, not the library internals)
-- Configuration assumptions (if the behavior would surprise you if it changed, test it)
-
-The inverse: if behavior changes and no test breaks, that behavior was untested. It is not safe to change — it is merely unverified to be safe. Add the test now.
-
-## Coincidence Articulation
-
-Tests that mirror the implementation's structure detect nothing — they fail together or pass together regardless of correctness.
-
-**Rule:** The test must reason about the problem independently from the implementation.
-- Test input/output contracts, not internal data structures
-- Test what the function is supposed to do, not how it currently does it
-- If the test would pass for any implementation that uses the same algorithm, it is not testing a contract — it is testing an implementation coincidence
-
-Signal: if modifying the test file requires looking at the source file, the test is mirroring implementation structure. The test MUST be written from requirements, not from reading the implementation.
-
-- Use `EXPECT_*` (non-fatal) for most assertions; use `ASSERT_*` (fatal) only when a test cannot meaningfully continue after failure
-- If a test seems to test external library behavior, focus on the wrapper/integration instead
-- If Arrange and Act are identical, the test is a constructor test — put expected values in Arrange, constructor call in Act
+When test work is complete, load the `self-evaluation` skill and follow its steps.
 
 ---
 
 ## CI Pipeline Rules
 
-For CI workflow rules (artifact uploads, permissions, PR comments), see the `workflow` skill (`.github/skills/workflow/`).
+For CI workflow rules (artifact uploads, permissions, PR comments), see the `workflow` skill.
 
 ---
 
@@ -313,3 +141,4 @@ For CI workflow rules (artifact uploads, permissions, PR comments), see the `wor
 - `code-quality` — clang-format and naming conventions apply to test code too
 
 **Testing principles (T2–T4):** See the `contract-testing` skill — unit tests as constraints, acceptance vs unit boundary, simplicity check
+

--- a/.github/skills/testing/SKILL.md
+++ b/.github/skills/testing/SKILL.md
@@ -107,6 +107,8 @@ If you catch yourself thinking any of these, STOP and start over with RED:
 
 **All of these mean: Delete any code written before the test. Start over with RED.**
 
+See `references/TESTING_EXAMPLES.md` for the Agile Alarm Bell warning on refactoring without tests.
+
 ---
 
 ## Rationalization Prevention

--- a/.github/skills/testing/SKILL.md
+++ b/.github/skills/testing/SKILL.md
@@ -72,7 +72,7 @@ For PV-specific test patterns (Camera, SettingsIO examples), test double taxonom
 
 ---
 
-## Step 5: Self-Review Checklist
+## Step 3: Self-Review Checklist
 
 Before presenting tests, verify:
 
@@ -143,4 +143,11 @@ For CI workflow rules (artifact uploads, permissions, PR comments), see the `wor
 - `code-quality` — clang-format and naming conventions apply to test code too
 
 **Testing principles (T2–T4):** See the `contract-testing` skill — unit tests as constraints, acceptance vs unit boundary, simplicity check
+
+---
+
+## Reference Files
+
+- `references/testing-anti-patterns.md` — common testing anti-patterns (mocking concrete types, testing mock behavior, test-only methods)
+- `references/TEST_SMELLS.md` — test smells catalog (Fowler/van Deursen): patterns that undermine reliability, readability, or correctness
 

--- a/.github/skills/testing/SKILL.md
+++ b/.github/skills/testing/SKILL.md
@@ -41,7 +41,7 @@ For PV test runner commands, see `references/PV_TEST_CONVENTIONS.md`.
 - **Unit test** — single class/function in isolation → `tests/core/`
 - **Integration test** — component interactions → `tests/integration/`
 - **Visual regression test** — pixel comparison → load `visual-regression-testing` skill
-- **Test review** — check existing tests against standards → apply checklist in Step 5
+- **Test review** — check existing tests against standards → apply checklist in Step 3
 
 ---
 
@@ -51,13 +51,7 @@ Every test MUST have three distinct comment sections: `// Arrange`, `// Act`, `/
 
 See `references/TESTING_EXAMPLES.md` for code examples and advanced patterns.
 
-### Critical Rules
-
-1. **NEVER combine phases.** Do not write `// Arrange & Act` or `// Act & Assert`. Each phase gets its own comment and section.
-   - **Exception:** `// Act & Assert` is acceptable only for `EXPECT_NO_THROW`/`EXPECT_THROW` tests where the action IS the assertion.
-2. **If no Arrange is needed**, omit `// Arrange` entirely — start with `// Act`.
-3. **Move expected values to Arrange** as named variables, not inline in Assert.
-4. **One logical concept per test** — split if testing multiple behaviors.
+For the complete AAA rule set and examples, see `references/TESTING_EXAMPLES.md`.
 
 ### Naming Convention
 
@@ -148,6 +142,6 @@ For CI workflow rules (artifact uploads, permissions, PR comments), see the `wor
 
 ## Reference Files
 
-- `references/testing-anti-patterns.md` — common testing anti-patterns (mocking concrete types, testing mock behavior, test-only methods)
+- `references/testing-anti-patterns.md` — common testing anti-patterns (testing mock behavior, test-only methods in production classes, mocking without understanding, incomplete mock data, visual regression tests without Red-Green)
 - `references/TEST_SMELLS.md` — test smells catalog (Fowler/van Deursen): patterns that undermine reliability, readability, or correctness
 

--- a/.github/skills/testing/SKILL.md
+++ b/.github/skills/testing/SKILL.md
@@ -49,9 +49,7 @@ For PV test runner commands, see `references/PV_TEST_CONVENTIONS.md`.
 
 Every test MUST have three distinct comment sections: `// Arrange`, `// Act`, `// Assert`.
 
-See `references/TESTING_EXAMPLES.md` for code examples and advanced patterns.
-
-For the complete AAA rule set and examples, see `references/TESTING_EXAMPLES.md`.
+For the complete AAA rule set, code examples, and advanced patterns, see `references/TESTING_EXAMPLES.md`.
 
 ### Naming Convention
 

--- a/.github/skills/testing/references/PV_TEST_CONVENTIONS.md
+++ b/.github/skills/testing/references/PV_TEST_CONVENTIONS.md
@@ -77,3 +77,68 @@ File naming: each test file matches its source — `CameraTests.cpp` tests `came
 ---
 
 For project test runner commands, see the `execution` skill.
+
+---
+
+## Test Double Taxonomy
+
+Use the **least sophisticated double** that answers your question. Reaching for `EXPECT_CALL` when a stub suffices is over-engineering.
+
+| Double | Behavior | Verifies Calls? | When to Use |
+|--------|----------|-----------------|-------------|
+| **Stub** | No-op methods; returns null/zero/false | No | You need `IOpenGLContext` to not crash; you don't care what it called |
+| **Fake** | Returns programmable values via setters | No | You need to control what `glGetError()` returns without interaction verification |
+| **Mock** | Returns values AND verifies call expectations | Yes — test fails if expected calls are not made | You must assert `glDrawArrays` was called exactly once with specific arguments |
+| **Shunt / SelfShunt** | The test fixture itself implements the interface | Inspected in teardown | Lowest setup overhead when the fixture plays both collaborator and verifier |
+
+**Google Mock mapping:** Stub → subclass returning constants. Fake → subclass with setters. Mock → `MOCK_METHOD` + `EXPECT_CALL` + `Times()`. Shunt → `TEST_F` fixture inherits from the interface.
+
+**Key principle:** Mock the *role* (interface), not the concrete object. `MockOpenGLContext` mocks `IOpenGLContext` — stable across implementation changes.
+
+**When NOT to use Google Mock:** If the question is "does this run without crashing?", a stub suffices. Only use `EXPECT_CALL` when the interaction itself is the behavior under test.
+
+---
+
+## Directory Structure and File Naming
+
+- `tests/core/` — Unit tests for `src/*.hpp` classes
+- `tests/integration/` — Multi-component tests
+- `tests/testing/` — Tests for test utilities (PixelComparator, Image)
+- `tests/visual-regression/` — Visual regression tests
+- `tests/mocks/` — Mock implementations
+
+File naming: each test file matches its source — `CameraTests.cpp` tests `camera.hpp`.
+
+Test ordering within a file: basic → complex, common → edge cases.
+
+---
+
+## Test Size Taxonomy (SE@G Model)
+
+Apply this taxonomy when classifying tests and deciding where they belong:
+
+| Size | Resource use | Scope | Directory |
+|------|-------------|-------|-----------|
+| **Small** | No I/O, no network, no filesystem, no external processes, no OpenGL context | Single unit in memory | `tests/` root or subdirectory |
+| **Medium** | Localhost I/O permitted (files, sockets), no external services, no real OpenGL | Component interactions, file I/O | `tests/integration/` |
+| **Large** | Real OpenGL context, real GPU, external processes, full system | End-to-end rendering, visual output | `tests/visual-regression/` |
+
+**Classification gate:** Before writing a test, classify it. If a "unit test" uses a real file, it is Medium. If it uses a real OpenGL context, it is Large. Misclassified tests in the wrong directory produce slow/unreliable CI runs.
+
+---
+
+## Additional Rationalization Prevention Rows
+
+These supplement the core rows kept in SKILL.md:
+
+| Excuse | Reality |
+|--------|---------|
+| "Tests after achieve the same goals" | Tests-after answer "what does this do?" Tests-first answer "what SHOULD this do?" |
+| "Deleting X hours of work is wasteful" | Sunk cost. Keeping untested code is technical debt. |
+| "The bug was a one-off, no regression test needed" | One-off bugs recur after the next refactoring. A regression test takes 5 minutes; a re-investigation takes hours. |
+
+Additional Red Flags — STOP:
+
+- "Tests after achieve the same goals"
+- "Just this once" or "This is different because..."
+- "I need to get the implementation right before I know what to test"

--- a/.github/skills/testing/references/PV_TEST_CONVENTIONS.md
+++ b/.github/skills/testing/references/PV_TEST_CONVENTIONS.md
@@ -99,17 +99,7 @@ Use the **least sophisticated double** that answers your question. Reaching for 
 
 ---
 
-### Directory Structure
-
-- `tests/core/` — Unit tests for `src/*.hpp` classes
-- `tests/integration/` — Multi-component tests
-- `tests/testing/` — Tests for test utilities (PixelComparator, Image)
-- `tests/visual-regression/` — Visual regression tests
-- `tests/mocks/` — Mock implementations
-
-### File Naming
-
-Each test file matches its source: `CameraTests.cpp` tests `camera.hpp`.
+For directory layout and file naming conventions, see **Test File Organization** above.
 
 ### Test Ordering
 

--- a/.github/skills/testing/references/PV_TEST_CONVENTIONS.md
+++ b/.github/skills/testing/references/PV_TEST_CONVENTIONS.md
@@ -99,7 +99,7 @@ Use the **least sophisticated double** that answers your question. Reaching for 
 
 ---
 
-## Directory Structure and File Naming
+### Directory Structure
 
 - `tests/core/` — Unit tests for `src/*.hpp` classes
 - `tests/integration/` — Multi-component tests
@@ -107,9 +107,13 @@ Use the **least sophisticated double** that answers your question. Reaching for 
 - `tests/visual-regression/` — Visual regression tests
 - `tests/mocks/` — Mock implementations
 
-File naming: each test file matches its source — `CameraTests.cpp` tests `camera.hpp`.
+### File Naming
 
-Test ordering within a file: basic → complex, common → edge cases.
+Each test file matches its source: `CameraTests.cpp` tests `camera.hpp`.
+
+### Test Ordering
+
+Within a file, order tests: basic → complex, common → edge cases.
 
 ---
 

--- a/.github/skills/testing/references/TESTING_EXAMPLES.md
+++ b/.github/skills/testing/references/TESTING_EXAMPLES.md
@@ -423,3 +423,9 @@ Signal: if modifying the test file requires looking at the source file, the test
 - Use `EXPECT_*` (non-fatal) for most assertions; use `ASSERT_*` (fatal) only when a test cannot meaningfully continue after failure
 - If a test seems to test external library behavior, focus on the wrapper/integration instead
 - If Arrange and Act are identical, the test is a constructor test — put expected values in Arrange, constructor call in Act
+
+---
+
+## Agile Alarm Bell
+
+**Agile Alarm Bell:** "Let's refactor without writing tests first" is the most dangerous phrase pair in software. Refactoring without a test suite to hold behavior constant is not refactoring — it is reckless restructuring. Stop. Write characterization tests first. Then refactor.

--- a/.github/skills/testing/references/TESTING_EXAMPLES.md
+++ b/.github/skills/testing/references/TESTING_EXAMPLES.md
@@ -7,6 +7,7 @@ This reference provides concrete examples of correct and incorrect test patterns
 ## AAA Pattern — Critical Rules
 
 1. **NEVER combine phases.** Do not write `// Arrange & Act` or `// Act & Assert`. Each phase gets its own comment and section.
+   - **Exception:** `// Act & Assert` is acceptable only for `EXPECT_NO_THROW`/`EXPECT_THROW` tests where the action IS the assertion.
 2. **If no Arrange is needed**, omit `// Arrange` entirely — start with `// Act`.
 3. **Move expected values to Arrange** as named variables, not inline in Assert.
 4. **One logical concept per test** — split if testing multiple behaviors.

--- a/.github/skills/testing/references/TESTING_EXAMPLES.md
+++ b/.github/skills/testing/references/TESTING_EXAMPLES.md
@@ -368,3 +368,58 @@ tests/
 ├── stb_image_write_impl.cpp
 └── CMakeLists.txt
 ```
+
+---
+
+## AAA Pattern — Template (Three Phases)
+
+```cpp
+TEST(SuiteName, MethodName_Condition_ExpectedResult)
+{
+    // Arrange
+    // Set up test preconditions, create objects, define expected values
+
+    // Act
+    // Execute the single operation being tested
+
+    // Assert
+    // Verify the outcome
+}
+```
+
+---
+
+## PV Naming Examples
+
+Use format: `UnitName_StateUnderTest_ExpectedResult`
+
+- `Compare_IdenticalImages_ReturnsMatch`
+- `ParsePPM_InvalidFile_ReturnsEmptyData`
+
+---
+
+## The Depended-Upon Behavior Rule
+
+Any behavior that your code **relies upon** must have a test. This applies to:
+- Your own functions (don't assume they work; prove it)
+- Libraries you depend on (test the integration point, not the library internals)
+- Configuration assumptions (if the behavior would surprise you if it changed, test it)
+
+The inverse: if behavior changes and no test breaks, that behavior was untested. It is not safe to change — it is merely unverified to be safe. Add the test now.
+
+---
+
+## Coincidence Articulation
+
+Tests that mirror the implementation's structure detect nothing — they fail together or pass together regardless of correctness.
+
+**Rule:** The test must reason about the problem independently from the implementation.
+- Test input/output contracts, not internal data structures
+- Test what the function is supposed to do, not how it currently does it
+- If the test would pass for any implementation that uses the same algorithm, it is not testing a contract — it is testing an implementation coincidence
+
+Signal: if modifying the test file requires looking at the source file, the test is mirroring implementation structure. The test MUST be written from requirements, not from reading the implementation.
+
+- Use `EXPECT_*` (non-fatal) for most assertions; use `ASSERT_*` (fatal) only when a test cannot meaningfully continue after failure
+- If a test seems to test external library behavior, focus on the wrapper/integration instead
+- If Arrange and Act are identical, the test is a constructor test — put expected values in Arrange, constructor call in Act

--- a/.github/skills/user-story-generator/SKILL.md
+++ b/.github/skills/user-story-generator/SKILL.md
@@ -49,7 +49,8 @@ Every generated story MUST be:
 
 If a story violates INVEST, fix it or suggest breaking it down.
 
-See `references/INVEST_GUIDE.md` for elaboration and examples for each INVEST criterion.
+See `references/INVEST_GUIDE.md` for conversation principles and common edge cases.
+See `references/INVEST_FRAMEWORK.md` for per-criterion elaboration and examples.
 
 ## Story Format
 

--- a/.github/skills/user-story-generator/SKILL.md
+++ b/.github/skills/user-story-generator/SKILL.md
@@ -87,7 +87,7 @@ See `references/STORY_TEMPLATE.md` for the full story template with all sections
 # Instructions for Agent
 
 See `references/CONVERSATION_SCRIPTS.md` for story elicitation conversation scripts.
-See `references/PV_PROJECT_CONTEXT.md` for Particle-Viewer project context and persona definitions.
+See `references/PV_PROJECT_CONTEXT.md` for project scope verification and reference loading guide.
 
 **Always load `references/PV_PROJECT_CONTEXT.md` FIRST before generating any story.**
 

--- a/.github/skills/user-story-generator/SKILL.md
+++ b/.github/skills/user-story-generator/SKILL.md
@@ -16,6 +16,49 @@ YOU MUST validate every story against all six INVEST criteria (Independent, Nego
 
 **Announce at start:** "I am using the user-story-generator skill to create/refine a story for [brief description]."
 
+## BEFORE PROCEEDING
+
+After you've had the conversation and before generating, mentally verify you have:
+- [ ] **Verified this aligns with actual project purpose** (loaded project context)
+- [ ] **Confirmed the functionality/component actually exists** (didn't assume based on naming)
+- [ ] Clear understanding of what they want to accomplish
+- [ ] Context about why it matters (the value)
+- [ ] Rough scope and size estimate (S/M/L)
+- [ ] Premium request estimate based on complexity
+- [ ] Model recommendation with reasoning
+- [ ] Format preference (if they expressed one)
+- [ ] Any specific constraints or requirements
+
+**If any of these are unclear, ask one more clarifying question before generating.**
+
+**RED FLAGS - Stop and ask for clarification:**
+- Story mentions functionality not in project context
+- Acceptance criteria test features that don't exist
+- Technical notes reference non-existent architecture
+- User story assumes capabilities the project doesn't have
+
+## INVEST Checklist
+
+Every generated story MUST be:
+- **Independent** – no hard dependencies on unstarted work
+- **Negotiable** – focus on "what" not "how"
+- **Valuable** – clear benefit stated in "So that" clause
+- **Estimable** – team can size it (provide S/M/L estimate)
+- **Small** – doable in one sprint
+- **Testable** – acceptance criteria are verifiable
+
+If a story violates INVEST, fix it or suggest breaking it down.
+
+See `references/INVEST_GUIDE.md` for elaboration and examples for each INVEST criterion.
+
+## Story Format
+
+**As a** [role: developer, tester, user]  
+**I want to** [action]  
+**So that** [outcome/business value]
+
+See `references/STORY_TEMPLATE.md` for the full story template with all sections.
+
 ## Rationalization Prevention
 
 | Excuse | Reality |
@@ -42,361 +85,16 @@ YOU MUST validate every story against all six INVEST criteria (Independent, Nego
 
 # Instructions for Agent
 
-## How This Skill is Invoked
+See `references/CONVERSATION_SCRIPTS.md` for story elicitation conversation scripts.
+See `references/PV_PROJECT_CONTEXT.md` for Particle-Viewer project context and persona definitions.
 
-In VS Code, users will activate this skill by:
-- Typing `@workspace /user-story-generator [description]` in Copilot Chat
-- Or simply asking: "Create a user story for [feature/task]" when this skill is available
-
-When activated, engage in a conversational process to build the story collaboratively.
-
----
-
-When this skill is activated, your goal is to **collaborate conversationally** with the user to build an excellent INVEST-aligned user story. Focus on understanding their needs through questions rather than rushing to generate output.
-
-## Core Approach: Conversation First, Generation Second
-
-**Do not immediately generate a story.** Instead, have a natural conversation to understand:
-- What they're trying to accomplish
-- Why it matters
-- What the scope and constraints are
-- Their preferences for format and detail
-
-Think of yourself as a helpful colleague who asks good questions.
-
-## Step 1: Understand the Request
-
-**CRITICAL: Verify Project Scope First**
-
-Before asking any other questions, **load and review** [references/PARTICLE_VIEWER_CONTEXT.md](references/PARTICLE_VIEWER_CONTEXT.md) to understand:
-- **What this project actually does** (it's a VIEWER for pre-computed simulations, NOT a simulator)
-- What components exist vs don't exist
-- Current architecture and pain points
-
-**Do NOT assume functionality based on project naming:**
-- "Particle-Viewer" = visualization tool, not physics engine
-- Reads particle data from files, doesn't compute physics
-- Focus on rendering, file I/O, camera controls, visual testing
-
-**If the user mentions functionality that doesn't exist in the project**, ask:
-> "Just to clarify—are you planning to add [feature], or did I misunderstand the scope? I want to make sure we're working on something that fits the project's purpose as a [viewer/simulator/etc]."
-
----
-
-Start by acknowledging what they've said and asking clarifying questions:
-
-### If they give you a clear topic:
-> "I'd love to help create that story! Let me ask a few questions to make sure I get it right:
-> 
-> 1. **What problem does this solve?** (What's the user/business value?)
-> 2. **Is this a feature, refactor, spike, or bug fix?**
-> 3. **Rough scope estimate**—is this small (few hours), medium (1-2 days), or larger?"
-
-### If their request is vague:
-> "I can help with that! To create a good story, could you tell me more about:
-> 
-> - What component or part of the system are we working on?
-> - What's the end goal or outcome you're looking for?
-> - Is there a specific pain point this addresses?"
-
-**Always allow them to override or redirect.** If they say "actually, let's focus on X instead," pivot immediately.
-
-## Step 2: Build Understanding Through Questions
-
-Based on their answers, ask **one or two follow-up questions** to clarify:
-
-### For features:
-- "Who's the primary user/beneficiary? (dev, tester, end user)"
-- "What does success look like for this feature?"
-- "Any specific constraints? (performance, compatibility, etc.)"
-
-### For refactors:
-- "What's making the current code hard to work with?"
-- "What would make it better? (e.g., easier to test, better separation of concerns)"
-- "Are we removing technical debt or enabling future work?"
-
-### For spikes:
-- "What's the key question we're trying to answer?"
-- "What would a successful spike deliver? (doc, PoC, recommendation)"
-- "What timebox are you targeting for this?"
-
-### For bugs:
-- "How do we reproduce this?"
-- "What's the impact? (crashes, incorrect behavior, performance)"
-- "Do we know the root cause, or is investigation needed?"
-
-**Keep questions natural and conversational.** Don't interrogate—ask what you genuinely need to know.
-
-## Step 3: Confirm Understanding Before Generating
-
-Once you have enough context through conversation, **summarize your understanding** and confirm:
-
-> "Got it! So we're creating a [type] story to [outcome], roughly [size] in scope. 
-> 
-> I'm thinking:
-> - **Title:** [proposed title]
-> - **Value:** [what this enables or fixes]
-> - **Key outcomes:** [2-3 bullet points]
-> 
-> Does that sound right, or do you want any adjustments before I write the full story?"
-
-This gives them a chance to course-correct before you generate the full story.
-
-**If they say "looks good" or "go ahead"**, proceed to Step 4.  
-**If they redirect or adjust**, update your understanding and re-confirm.
-
-## Step 4: Generate the Story
-
-Only after the user confirms, generate the story using this template:
-
-```markdown
-**Title:** [Story Name]
-
-**Type:** Feature | Refactor | Spike | Bug
-**Size:** S | M | L
-**Epic/Component:** [e.g., Visual Regression Testing, Code Refactoring]
-**Priority:** [High | Medium | Low]
-**Depends On:** [Issue numbers or "None"]
-
----
-
-## Effort Estimate
-
-**Total Premium Requests:** [Range, e.g., 30-40]
-**Recommended Model Tier:** [Small | Standard | Advanced]
-**Reasoning:** [One sentence explaining complexity level and why this tier is appropriate]
-
----
-
-## User Story
-
-**As a** [role: developer, tester, user]  
-**I want to** [action]  
-**So that** [outcome/business value]
-
----
-
-## Acceptance Criteria
-
-- [ ] [Specific, measurable outcome]
-- [ ] [Another measurable outcome]
-- [ ] [Edge case or constraint]
-
----
-
-## Technical Notes
-
-**Dependencies:**
-- [Other stories, external packages, or "None"]
-
-**Constraints:**
-- [Platform requirements, performance targets]
-
-**Files to Create/Modify:**
-- [List of modules with specific file paths]
-
-**Architecture Notes:** [If applicable]
-- [Design patterns, extensibility considerations]
-
----
-
-## Definition of Done
-
-- [ ] Code written and peer-reviewed
-- [ ] Unit tests pass (min. 85% coverage on new code)
-- [ ] No new linter/compiler warnings
-- [ ] Documentation updated
-- [ ] Integration tested
-- [ ] Ready to merge to main branch
-
----
-
-## Comments
-
-[Optional: Next steps, related work, or important context]
-```
-
-**Make the story specific and actionable.** Use concrete metrics, file paths, and technical details where appropriate.
-
-**If the story seems too large (L-sized or epic)**, mention this after generating and suggest breaking it down:
-> "This is a larger effort that will take 2-3+ days. Would you like me to break it into 3-4 smaller, independent stories?"
-
-## Estimating Effort and Model Selection
-
-Load the `user-story-estimation` skill (`.github/skills/user-story-estimation/`) for S/M/L size breakdown, premium request ranges, model tier selection, and validated examples. Always include the Effort Estimate section in every generated story.
-
-## Step 5: Continue the Conversation
-
-After generating the story, **invite feedback and refinement**:
-
-> "I've written up the story above. What do you think?
-> 
-> I can:
-> - Break this into smaller subtasks if it's too big
-> - Add more specific acceptance criteria
-> - Adjust the scope or format
-> - Create a simpler Definition of Done
-> 
-> Or if it looks good, we can call it done!"
-
-**Always be ready to iterate.** The story is a draft, not final. Treat every response as an invitation to refine.
-
-### If they want changes:
-Make them immediately and conversationally:
-> "Got it—I've updated the [section] to [change]. Here's the revised version..."
-
-### If they want breakdown:
-Ask how they want it split:
-> "Should I break this into independent stories by component, or sequential subtasks for one person?"
-
-### If they want to create a GitHub issue:
-Offer to format it:
-> "Would you like this formatted for a GitHub issue? I can structure it with proper markdown and labels."
-
-## Using Project Context
-
-**ALWAYS load project context FIRST before generating any story.**
-
-Throughout the conversation, Load project-specific references **when needed**:
-
-### For Particle-Viewer stories:
-**Load [references/PARTICLE_VIEWER_CONTEXT.md](references/PARTICLE_VIEWER_CONTEXT.md) IMMEDIATELY when:**
-- User requests ANY story for this project
-- Before asking clarifying questions (so you ask the RIGHT questions)
-- Need to understand what actually exists vs assumptions
-
-**Use it to verify:**
-- Is this feature request aligned with project purpose?
-- Does this component/functionality actually exist?
-- Are we focusing on real value (rendering, I/O, visualization) or imagined features (physics simulation)?
-
-### For INVEST validation:
-Load [references/INVEST_FRAMEWORK.md](references/INVEST_FRAMEWORK.md) when:
-- User asks "what makes a good story?"
-- Story seems to violate INVEST principles
-- Need to explain why you're suggesting certain changes
-
-### For story examples:
-Load [references/STORY_TEMPLATES.md](references/STORY_TEMPLATES.md) when:
-- User is new to story writing
-- Need to show format variations (BDD vs bullets)
-- Asked for examples of features, refactors, spikes, or bugs
-
-**Don't load all references upfront.** Use progressive disclosure—load only what you need when you need it.
-
-## Key Principles
-
-### Prioritize Conversation Over Generation
-**Your primary mode is conversation, not generation.** Spend time understanding the user's needs through dialogue before rushing to create a story. This ensures:
-- The story actually solves their problem
-- They feel heard and involved
-- The final output is tailored to their context
-- You avoid rework from misunderstanding
-
-Think: "Let's figure this out together" not "Let me generate this for you."
-
-### Be Conversational and Amicable
-Use natural, collaborative language. Avoid robotic input/output framing.
-
-### Always Allow Overrides
-Accept all redirects immediately. Never defend your interpretation.
-
-### Embrace Progressive Disclosure
-**Don't front-load everything.** Build understanding gradually:
-1. Start with minimal questions (just enough to understand the goal)
-2. Ask 1-2 follow-ups based on their answers
-3. Summarize and confirm
-4. Generate the story
-5. Invite iteration
-
-Avoid 10-question interrogations. Keep the flow natural.
-
-### Build Rapport Through Questions
-Good questions show you're listening and thinking:
-- "What's making this hard to work on right now?"
-- "What would 'done' look like for this?"
-- "Are we fixing something that's broken, or enabling new work?"
-
-These are better than:
-- "What is the acceptance criteria?"
-- "Provide story type and size estimate."
-
-### Make Stories INVEST-Compliant
-Every generated story MUST be:
-- **Independent** – no hard dependencies on unstarted work
-- **Negotiable** – focus on "what" not "how"
-- **Valuable** – clear benefit stated in "So that" clause
-- **Estimable** – team can size it (provide S/M/L estimate)
-- **Small** – doable in one sprint
-- **Testable** – acceptance criteria are verifiable
-
-If a story violates INVEST, fix it or suggest breaking it down.
-
-### Avoid Vague Language
-❌ "Code should be clean"  
-✅ "Cyclomatic complexity reduced from 15 to 8"
-
-❌ "Performance should improve"  
-✅ "Frame capture completes in ≤16ms (60 FPS budget)"
-
-❌ "UI should look good"  
-✅ "Dashboard displays last 10 activities with <200ms load time"
-
-### Include Concrete Details for Your Project
-
-When generating stories, reference project-specific files, naming conventions, CI requirements, and test framework conventions. For Particle-Viewer specifics, see `references/PARTICLE_VIEWER_CONTEXT.md`.
-
-## Common Edge Cases
-
-**User provides very vague request**  
-Ask clarifying questions, but keep moving forward. Example:
-> "Create a story for testing"
-
-Response:
-> "Got it! Testing what specifically—visual regression, unit tests for a component, or integration tests? Also, is this for existing code or new functionality?"
-
-**User wants to refactor globals**  
-This is a common Particle-Viewer task. Consult [references/PARTICLE_VIEWER_CONTEXT.md](references/PARTICLE_VIEWER_CONTEXT.md) for refactoring patterns.
-
-**Story is too large (L or epic-sized)**  
-Suggest breaking it down:
-> "This feels like a larger effort (2-3 days or more). Would you like me to break it into 3-4 smaller stories that can be worked on independently?"
-
-**User overrides your suggestion**  
-Accept it gracefully:
-> "Got it—adjusted to [their preference]. Here's the updated version..."
-
-## Before Presenting the Final Story
-
-After you've had the conversation and before generating, mentally verify you have:
-- [ ] **Verified this aligns with actual project purpose** (loaded project context)
-- [ ] **Confirmed the functionality/component actually exists** (didn't assume based on naming)
-- [ ] Clear understanding of what they want to accomplish
-- [ ] Context about why it matters (the value)
-- [ ] Rough scope and size estimate (S/M/L)
-- [ ] Premium request estimate based on complexity
-- [ ] Model recommendation with reasoning
-- [ ] Format preference (if they expressed one)
-- [ ] Any specific constraints or requirements
-
-**If any of these are unclear, ask one more clarifying question before generating.**
-
-**RED FLAGS - Stop and ask for clarification:**
-- Story mentions functionality not in project context
-- Acceptance criteria test features that don't exist
-- Technical notes reference non-existent architecture
-- User story assumes capabilities the project doesn't have
+**Always load `references/PV_PROJECT_CONTEXT.md` FIRST before generating any story.**
 
 **Always include the Effort Estimate section** with:
 - Total premium requests (range)
 - Recommended model tier (Small/Standard/Advanced)
 - One-sentence reasoning for the model choice
 
-## After Generating the Story
+## Related Skills
 
-Present it and immediately invite refinement:
-- [ ] Did I capture what you wanted?
-- [ ] Would you like me to adjust anything?
-- [ ] Should we break this down further?
-
-The story is never "final" until the user says so. Always be ready for another iteration.
+See the `user-story-estimation` skill for S/M/L size breakdown, premium request ranges, model tier selection, and validated examples. Always include the Effort Estimate section in every generated story.

--- a/.github/skills/user-story-generator/references/CONVERSATION_SCRIPTS.md
+++ b/.github/skills/user-story-generator/references/CONVERSATION_SCRIPTS.md
@@ -1,3 +1,5 @@
+# Story Elicitation Conversation Scripts
+
 ## How This Skill is Invoked
 
 In VS Code, users will activate this skill by:
@@ -83,6 +85,12 @@ This gives them a chance to course-correct before you generate the full story.
 
 **If they say "looks good" or "go ahead"**, proceed to Step 4.  
 **If they redirect or adjust**, update your understanding and re-confirm.
+
+---
+
+**Step 4 — Generate the Story:** See `references/STORY_TEMPLATE.md` for the full story template.
+
+---
 
 ## Step 5: Continue the Conversation
 

--- a/.github/skills/user-story-generator/references/CONVERSATION_SCRIPTS.md
+++ b/.github/skills/user-story-generator/references/CONVERSATION_SCRIPTS.md
@@ -1,0 +1,122 @@
+## How This Skill is Invoked
+
+In VS Code, users will activate this skill by:
+- Typing `@workspace /user-story-generator [description]` in Copilot Chat
+- Or simply asking: "Create a user story for [feature/task]" when this skill is available
+
+When activated, engage in a conversational process to build the story collaboratively.
+
+---
+
+When this skill is activated, your goal is to **collaborate conversationally** with the user to build an excellent INVEST-aligned user story. Focus on understanding their needs through questions rather than rushing to generate output.
+
+## Core Approach: Conversation First, Generation Second
+
+**Do not immediately generate a story.** Instead, have a natural conversation to understand:
+- What they're trying to accomplish
+- Why it matters
+- What the scope and constraints are
+- Their preferences for format and detail
+
+Think of yourself as a helpful colleague who asks good questions.
+
+## Step 1: Understand the Request
+
+Start by acknowledging what they've said and asking clarifying questions:
+
+### If they give you a clear topic:
+> "I'd love to help create that story! Let me ask a few questions to make sure I get it right:
+> 
+> 1. **What problem does this solve?** (What's the user/business value?)
+> 2. **Is this a feature, refactor, spike, or bug fix?**
+> 3. **Rough scope estimate**—is this small (few hours), medium (1-2 days), or larger?"
+
+### If their request is vague:
+> "I can help with that! To create a good story, could you tell me more about:
+> 
+> - What component or part of the system are we working on?
+> - What's the end goal or outcome you're looking for?
+> - Is there a specific pain point this addresses?"
+
+**Always allow them to override or redirect.** If they say "actually, let's focus on X instead," pivot immediately.
+
+## Step 2: Build Understanding Through Questions
+
+Based on their answers, ask **one or two follow-up questions** to clarify:
+
+### For features:
+- "Who's the primary user/beneficiary? (dev, tester, end user)"
+- "What does success look like for this feature?"
+- "Any specific constraints? (performance, compatibility, etc.)"
+
+### For refactors:
+- "What's making the current code hard to work with?"
+- "What would make it better? (e.g., easier to test, better separation of concerns)"
+- "Are we removing technical debt or enabling future work?"
+
+### For spikes:
+- "What's the key question we're trying to answer?"
+- "What would a successful spike deliver? (doc, PoC, recommendation)"
+- "What timebox are you targeting for this?"
+
+### For bugs:
+- "How do we reproduce this?"
+- "What's the impact? (crashes, incorrect behavior, performance)"
+- "Do we know the root cause, or is investigation needed?"
+
+**Keep questions natural and conversational.** Don't interrogate—ask what you genuinely need to know.
+
+## Step 3: Confirm Understanding Before Generating
+
+Once you have enough context through conversation, **summarize your understanding** and confirm:
+
+> "Got it! So we're creating a [type] story to [outcome], roughly [size] in scope. 
+> 
+> I'm thinking:
+> - **Title:** [proposed title]
+> - **Value:** [what this enables or fixes]
+> - **Key outcomes:** [2-3 bullet points]
+> 
+> Does that sound right, or do you want any adjustments before I write the full story?"
+
+This gives them a chance to course-correct before you generate the full story.
+
+**If they say "looks good" or "go ahead"**, proceed to Step 4.  
+**If they redirect or adjust**, update your understanding and re-confirm.
+
+## Step 5: Continue the Conversation
+
+After generating the story, **invite feedback and refinement**:
+
+> "I've written up the story above. What do you think?
+> 
+> I can:
+> - Break this into smaller subtasks if it's too big
+> - Add more specific acceptance criteria
+> - Adjust the scope or format
+> - Create a simpler Definition of Done
+> 
+> Or if it looks good, we can call it done!"
+
+**Always be ready to iterate.** The story is a draft, not final. Treat every response as an invitation to refine.
+
+### If they want changes:
+Make them immediately and conversationally:
+> "Got it—I've updated the [section] to [change]. Here's the revised version..."
+
+### If they want breakdown:
+Ask how they want it split:
+> "Should I break this into independent stories by component, or sequential subtasks for one person?"
+
+### If they want to create a GitHub issue:
+Offer to format it:
+> "Would you like this formatted for a GitHub issue? I can structure it with proper markdown and labels."
+
+## After Generating the Story
+
+Present it and immediately invite refinement:
+- [ ] Did I capture what you wanted?
+- [ ] Would you like me to adjust anything?
+- [ ] Should we break this down further?
+
+The story is never "final" until the user says so. Always be ready for another iteration.

--- a/.github/skills/user-story-generator/references/INVEST_GUIDE.md
+++ b/.github/skills/user-story-generator/references/INVEST_GUIDE.md
@@ -67,7 +67,7 @@ Response:
 > "Got it! Testing what specifically—visual regression, unit tests for a component, or integration tests? Also, is this for existing code or new functionality?"
 
 **User wants to refactor globals**  
-This is a common Particle-Viewer task. Consult [references/PARTICLE_VIEWER_CONTEXT.md](references/PARTICLE_VIEWER_CONTEXT.md) for refactoring patterns.
+This is a common Particle-Viewer task. Consult `references/PARTICLE_VIEWER_CONTEXT.md` for refactoring patterns.
 
 **Story is too large (L or epic-sized)**  
 Suggest breaking it down:

--- a/.github/skills/user-story-generator/references/INVEST_GUIDE.md
+++ b/.github/skills/user-story-generator/references/INVEST_GUIDE.md
@@ -1,3 +1,5 @@
+# INVEST Conversation Guide
+
 ## Key Principles
 
 ### Prioritize Conversation Over Generation
@@ -36,13 +38,8 @@ These are better than:
 - "Provide story type and size estimate."
 
 ### Make Stories INVEST-Compliant
-Every generated story MUST be:
-- **Independent** – no hard dependencies on unstarted work
-- **Negotiable** – focus on "what" not "how"
-- **Valuable** – clear benefit stated in "So that" clause
-- **Estimable** – team can size it (provide S/M/L estimate)
-- **Small** – doable in one sprint
-- **Testable** – acceptance criteria are verifiable
+
+The INVEST checklist is maintained inline in `SKILL.md`. See the INVEST Checklist section there.
 
 If a story violates INVEST, fix it or suggest breaking it down.
 

--- a/.github/skills/user-story-generator/references/INVEST_GUIDE.md
+++ b/.github/skills/user-story-generator/references/INVEST_GUIDE.md
@@ -1,0 +1,81 @@
+## Key Principles
+
+### Prioritize Conversation Over Generation
+**Your primary mode is conversation, not generation.** Spend time understanding the user's needs through dialogue before rushing to create a story. This ensures:
+- The story actually solves their problem
+- They feel heard and involved
+- The final output is tailored to their context
+- You avoid rework from misunderstanding
+
+Think: "Let's figure this out together" not "Let me generate this for you."
+
+### Be Conversational and Amicable
+Use natural, collaborative language. Avoid robotic input/output framing.
+
+### Always Allow Overrides
+Accept all redirects immediately. Never defend your interpretation.
+
+### Embrace Progressive Disclosure
+**Don't front-load everything.** Build understanding gradually:
+1. Start with minimal questions (just enough to understand the goal)
+2. Ask 1-2 follow-ups based on their answers
+3. Summarize and confirm
+4. Generate the story
+5. Invite iteration
+
+Avoid 10-question interrogations. Keep the flow natural.
+
+### Build Rapport Through Questions
+Good questions show you're listening and thinking:
+- "What's making this hard to work on right now?"
+- "What would 'done' look like for this?"
+- "Are we fixing something that's broken, or enabling new work?"
+
+These are better than:
+- "What is the acceptance criteria?"
+- "Provide story type and size estimate."
+
+### Make Stories INVEST-Compliant
+Every generated story MUST be:
+- **Independent** – no hard dependencies on unstarted work
+- **Negotiable** – focus on "what" not "how"
+- **Valuable** – clear benefit stated in "So that" clause
+- **Estimable** – team can size it (provide S/M/L estimate)
+- **Small** – doable in one sprint
+- **Testable** – acceptance criteria are verifiable
+
+If a story violates INVEST, fix it or suggest breaking it down.
+
+### Avoid Vague Language
+❌ "Code should be clean"  
+✅ "Cyclomatic complexity reduced from 15 to 8"
+
+❌ "Performance should improve"  
+✅ "Frame capture completes in ≤16ms (60 FPS budget)"
+
+❌ "UI should look good"  
+✅ "Dashboard displays last 10 activities with <200ms load time"
+
+### Include Concrete Details for Your Project
+
+When generating stories, reference project-specific files, naming conventions, CI requirements, and test framework conventions. For Particle-Viewer specifics, see `references/PARTICLE_VIEWER_CONTEXT.md`.
+
+## Common Edge Cases
+
+**User provides very vague request**  
+Ask clarifying questions, but keep moving forward. Example:
+> "Create a story for testing"
+
+Response:
+> "Got it! Testing what specifically—visual regression, unit tests for a component, or integration tests? Also, is this for existing code or new functionality?"
+
+**User wants to refactor globals**  
+This is a common Particle-Viewer task. Consult [references/PARTICLE_VIEWER_CONTEXT.md](references/PARTICLE_VIEWER_CONTEXT.md) for refactoring patterns.
+
+**Story is too large (L or epic-sized)**  
+Suggest breaking it down:
+> "This feels like a larger effort (2-3 days or more). Would you like me to break it into 3-4 smaller stories that can be worked on independently?"
+
+**User overrides your suggestion**  
+Accept it gracefully:
+> "Got it—adjusted to [their preference]. Here's the updated version..."

--- a/.github/skills/user-story-generator/references/PV_PROJECT_CONTEXT.md
+++ b/.github/skills/user-story-generator/references/PV_PROJECT_CONTEXT.md
@@ -4,7 +4,7 @@
 
 **CRITICAL: Verify Project Scope First**
 
-Before asking any other questions, **load and review** [references/PARTICLE_VIEWER_CONTEXT.md](references/PARTICLE_VIEWER_CONTEXT.md) to understand:
+Before asking any other questions, **load and review** `references/PARTICLE_VIEWER_CONTEXT.md` to understand:
 - **What this project actually does** (it's a VIEWER for pre-computed simulations, NOT a simulator)
 - What components exist vs don't exist
 - Current architecture and pain points
@@ -24,7 +24,7 @@ Before asking any other questions, **load and review** [references/PARTICLE_VIEW
 Throughout the conversation, Load project-specific references **when needed**:
 
 ### For Particle-Viewer stories:
-**Load [references/PARTICLE_VIEWER_CONTEXT.md](references/PARTICLE_VIEWER_CONTEXT.md) IMMEDIATELY when:**
+**Load `references/PARTICLE_VIEWER_CONTEXT.md` IMMEDIATELY when:**
 - User requests ANY story for this project
 - Before asking clarifying questions (so you ask the RIGHT questions)
 - Need to understand what actually exists vs assumptions
@@ -35,13 +35,13 @@ Throughout the conversation, Load project-specific references **when needed**:
 - Are we focusing on real value (rendering, I/O, visualization) or imagined features (physics simulation)?
 
 ### For INVEST validation:
-Load [references/INVEST_FRAMEWORK.md](references/INVEST_FRAMEWORK.md) when:
+Load `references/INVEST_FRAMEWORK.md` when:
 - User asks "what makes a good story?"
 - Story seems to violate INVEST principles
 - Need to explain why you're suggesting certain changes
 
 ### For story examples:
-Load [references/STORY_TEMPLATES.md](references/STORY_TEMPLATES.md) when:
+Load `references/STORY_TEMPLATES.md` when:
 - User is new to story writing
 - Need to show format variations (BDD vs bullets)
 - Asked for examples of features, refactors, spikes, or bugs

--- a/.github/skills/user-story-generator/references/PV_PROJECT_CONTEXT.md
+++ b/.github/skills/user-story-generator/references/PV_PROJECT_CONTEXT.md
@@ -1,3 +1,5 @@
+# Particle-Viewer Project Scope Gate
+
 ## Step 1: Understand the Request — Verify Project Scope First
 
 **CRITICAL: Verify Project Scope First**

--- a/.github/skills/user-story-generator/references/PV_PROJECT_CONTEXT.md
+++ b/.github/skills/user-story-generator/references/PV_PROJECT_CONTEXT.md
@@ -1,0 +1,47 @@
+## Step 1: Understand the Request — Verify Project Scope First
+
+**CRITICAL: Verify Project Scope First**
+
+Before asking any other questions, **load and review** [references/PARTICLE_VIEWER_CONTEXT.md](references/PARTICLE_VIEWER_CONTEXT.md) to understand:
+- **What this project actually does** (it's a VIEWER for pre-computed simulations, NOT a simulator)
+- What components exist vs don't exist
+- Current architecture and pain points
+
+**Do NOT assume functionality based on project naming:**
+- "Particle-Viewer" = visualization tool, not physics engine
+- Reads particle data from files, doesn't compute physics
+- Focus on rendering, file I/O, camera controls, visual testing
+
+**If the user mentions functionality that doesn't exist in the project**, ask:
+> "Just to clarify—are you planning to add [feature], or did I misunderstand the scope? I want to make sure we're working on something that fits the project's purpose as a [viewer/simulator/etc]."
+
+## Using Project Context
+
+**ALWAYS load project context FIRST before generating any story.**
+
+Throughout the conversation, Load project-specific references **when needed**:
+
+### For Particle-Viewer stories:
+**Load [references/PARTICLE_VIEWER_CONTEXT.md](references/PARTICLE_VIEWER_CONTEXT.md) IMMEDIATELY when:**
+- User requests ANY story for this project
+- Before asking clarifying questions (so you ask the RIGHT questions)
+- Need to understand what actually exists vs assumptions
+
+**Use it to verify:**
+- Is this feature request aligned with project purpose?
+- Does this component/functionality actually exist?
+- Are we focusing on real value (rendering, I/O, visualization) or imagined features (physics simulation)?
+
+### For INVEST validation:
+Load [references/INVEST_FRAMEWORK.md](references/INVEST_FRAMEWORK.md) when:
+- User asks "what makes a good story?"
+- Story seems to violate INVEST principles
+- Need to explain why you're suggesting certain changes
+
+### For story examples:
+Load [references/STORY_TEMPLATES.md](references/STORY_TEMPLATES.md) when:
+- User is new to story writing
+- Need to show format variations (BDD vs bullets)
+- Asked for examples of features, refactors, spikes, or bugs
+
+**Don't load all references upfront.** Use progressive disclosure—load only what you need when you need it.

--- a/.github/skills/user-story-generator/references/STORY_TEMPLATE.md
+++ b/.github/skills/user-story-generator/references/STORY_TEMPLATE.md
@@ -1,3 +1,5 @@
+# Story Template
+
 ## Step 4: Generate the Story
 
 Only after the user confirms, generate the story using this template:

--- a/.github/skills/user-story-generator/references/STORY_TEMPLATE.md
+++ b/.github/skills/user-story-generator/references/STORY_TEMPLATE.md
@@ -1,0 +1,79 @@
+## Step 4: Generate the Story
+
+Only after the user confirms, generate the story using this template:
+
+```markdown
+**Title:** [Story Name]
+
+**Type:** Feature | Refactor | Spike | Bug
+**Size:** S | M | L
+**Epic/Component:** [e.g., Visual Regression Testing, Code Refactoring]
+**Priority:** [High | Medium | Low]
+**Depends On:** [Issue numbers or "None"]
+
+---
+
+## Effort Estimate
+
+**Total Premium Requests:** [Range, e.g., 30-40]
+**Recommended Model Tier:** [Small | Standard | Advanced]
+**Reasoning:** [One sentence explaining complexity level and why this tier is appropriate]
+
+---
+
+## User Story
+
+**As a** [role: developer, tester, user]  
+**I want to** [action]  
+**So that** [outcome/business value]
+
+---
+
+## Acceptance Criteria
+
+- [ ] [Specific, measurable outcome]
+- [ ] [Another measurable outcome]
+- [ ] [Edge case or constraint]
+
+---
+
+## Technical Notes
+
+**Dependencies:**
+- [Other stories, external packages, or "None"]
+
+**Constraints:**
+- [Platform requirements, performance targets]
+
+**Files to Create/Modify:**
+- [List of modules with specific file paths]
+
+**Architecture Notes:** [If applicable]
+- [Design patterns, extensibility considerations]
+
+---
+
+## Definition of Done
+
+- [ ] Code written and peer-reviewed
+- [ ] Unit tests pass (min. 85% coverage on new code)
+- [ ] No new linter/compiler warnings
+- [ ] Documentation updated
+- [ ] Integration tested
+- [ ] Ready to merge to main branch
+
+---
+
+## Comments
+
+[Optional: Next steps, related work, or important context]
+```
+
+**Make the story specific and actionable.** Use concrete metrics, file paths, and technical details where appropriate.
+
+**If the story seems too large (L-sized or epic)**, mention this after generating and suggest breaking it down:
+> "This is a larger effort that will take 2-3+ days. Would you like me to break it into 3-4 smaller, independent stories?"
+
+## Estimating Effort and Model Selection
+
+Load the `user-story-estimation` skill for S/M/L size breakdown, premium request ranges, model tier selection, and validated examples. Always include the Effort Estimate section in every generated story.

--- a/.github/skills/user-story-generator/references/STORY_TEMPLATE.md
+++ b/.github/skills/user-story-generator/references/STORY_TEMPLATE.md
@@ -76,4 +76,5 @@ Only after the user confirms, generate the story using this template:
 
 ## Estimating Effort and Model Selection
 
+<!-- Path (.github/skills/user-story-estimation/) stripped — cross-skill path violation per Skill Composition Model -->
 Load the `user-story-estimation` skill for S/M/L size breakdown, premium request ranges, model tier selection, and validated examples. Always include the Effort Estimate section in every generated story.

--- a/.github/skills/user-story-generator/references/STORY_TEMPLATE.md
+++ b/.github/skills/user-story-generator/references/STORY_TEMPLATE.md
@@ -78,5 +78,4 @@ Only after the user confirms, generate the story using this template:
 
 ## Estimating Effort and Model Selection
 
-<!-- Path (.github/skills/user-story-estimation/) stripped — cross-skill path violation per Skill Composition Model -->
 Load the `user-story-estimation` skill for S/M/L size breakdown, premium request ranges, model tier selection, and validated examples. Always include the Effort Estimate section in every generated story.

--- a/.github/skills/verification-before-completion/SKILL.md
+++ b/.github/skills/verification-before-completion/SKILL.md
@@ -6,13 +6,6 @@ description: Use when about to claim work is complete, fixed, or passing, before
 
 # Instructions for Agent
 
-## How This Skill is Invoked
-
-This skill is **mandatory before any completion claim**. It applies before:
-- Saying "tests pass", "build succeeds", "bug is fixed", "feature complete", or "PR is ready"
-- Opening a commit message
-- Opening a pull request
-
 When activated, announce: **"I am using the verification-before-completion skill. Running verification now."**
 
 ---
@@ -44,13 +37,7 @@ Violating the letter of this rule is violating the spirit of this rule.
 
 **Gate:** Marking a todo "done" when unit tests pass = wrong definition. Invisible work remains.
 
-For this project (a desktop application, not a deployed service), the equivalent stages are:
-- "Locally verified" — builds + tests pass after the change
-- "Gate passed" — full pre-commit gate (build + tests + format + diff review) completed
-- "Committed" — code committed with passing gate
-- **"Done"** — committed, PR merged, branch clean
-
-Use stage vocabulary. Never use "Done" for a stage that is not the final stage.
+For Particle-Viewer–specific Done stages, see `references/PV_DONE_DEFINITION.md`.
 
 ---
 
@@ -76,48 +63,7 @@ Skipping any step = lying, not verifying.
 
 ---
 
-## 4 Cores Final Check
-
-The verification gate confirms **Results** — tests pass, build succeeds. But it cannot confirm the first three cores. Run this check *after* the gate, before claiming done.
-
-| Core | Question | What it catches |
-|------|----------|-----------------|
-| **Integrity** | Does the implementation match exactly what was committed — no more, no less? | Scope creep, partial delivery, undisclosed limitations |
-| **Intent** | Am I solving the stated problem, or the comfortable version of it? | Solving an easier adjacent problem; avoiding the hard requirement |
-| **Capabilities** | Is this the right solution, or just the first one that worked? | Technically-passing implementation that creates future maintenance burden |
-| **Results** | Can I show verifiable inline evidence? | Covered by the gate above — cite it explicitly |
-
-**Failing any core = do not claim done. Resolve the gap first.**
-
-The Results core is covered by the verification commands above. The first three are quality checks that evidence alone cannot catch — a test suite can pass while the wrong problem is solved perfectly.
-
-**Worst common violation — Intent:** An agent solves the easy part of a requirement (the part it's comfortable with) and presents it as the full solution. The tests pass. The build is clean. The requirement is not met. The 4 Cores check catches this by asking "did I solve what was asked, or what was convenient?"
-
----
-
-## Combine Verification Instruments
-
-**No single verification technique removes more than ~70% of defects.** (Capers Jones research, cited in McConnell's *Code Complete*.)
-
-| Technique | Defect removal efficiency |
-|-----------|--------------------------|
-| Unit testing alone | 30–40% |
-| Code inspection/review | 45–70% |
-| **Both combined** | **>90%** |
-
-The IBM Cleanroom result: formal inspections achieved <0.1 defects/KLOC vs. industry average 15–50.
-
-**The implication:** "Tests pass" with no additional review still has a statistically likely defect rate of 30–70%. Tests catch execution-time defects. Code review catches logical, requirements, and interface defects that tests cannot surface.
-
-**Gate for this project:**
-
-Before claiming any PR ready:
-1. **Tests pass** — execution-time defects caught
-2. **Diff reviewed** — logical and interface defects caught (`git diff` read hunk by hunk)
-3. **Format verified** — `clang-format --dry-run` clean
-4. **Scope verified** — changes touch only what the task required; no accidental changes
-
-**Rationalization:** "Tests pass — I'm done." Counter: no single technique removes >70% of defects. Tests + diff review is the minimum combined instrument set.
+See `references/VERIFICATION_THEORY.md` for defect removal efficiency data, trust ledger, and common failure modes.
 
 ---
 
@@ -151,80 +97,14 @@ These words and phrases **cannot appear in any response** unless fresh verificat
 | **`"Should work"`** | **BANNED. No substitute. Run the verification.** |
 | `"That should do it"` | BANNED. Same reason. |
 
-### Why "Should Work" Is Banned
-
-"Should work" combines the tone of having verified with the reality of not having verified. It is undetectable false confidence. A user reading "should work" cannot tell whether you ran the gate or not. Replace it with either:
-- Evidence: `"Ran [command]: [output]. It works."`
-- Honest uncertainty: `"Haven't verified yet — running the gate now."`
-
-### Required Evidence Format
-
 Evidence must be **inline**, not referenced:
 
 ❌ `"I ran the tests and they passed."`  
 ✅ `"Ran <project-test-runner>: **247 passed, 0 failures.** [exit 0]"`
 
-The inline format is self-auditing. The user cannot independently verify a reference claim. They can verify inline output by reading it.
-
-### Process Language (always available)
-
-Use freely when verification hasn't been run:
-- `"Running verification now..."`
-- `"Haven't run the gate yet — doing that now"`
-- `"Identified likely cause — confirming before claiming fix"`
-- `"Uncertain about X — dispatching subagent to confirm"`
-
 ---
 
-## The Verification Commands
-
-> **Note (Particle-Viewer specific):** The commands below use this project's build system and test runner. Adapt `cmake --build build`, `./build/tests/ParticleViewerTests`, and the `find src tests` glob for your own project.
-
-```bash
-# Build
-cmake --build build
-
-# Tests
-./build/tests/ParticleViewerTests
-
-# Format check
-find src tests -name "*.cpp" -o -name "*.hpp" | xargs clang-format --dry-run -Werror
-
-# Full pre-commit gate (run all three before every commit)
-find src tests -name "*.cpp" -o -name "*.hpp" | xargs clang-format -i
-cmake --build build && ./build/tests/ParticleViewerTests
-```
-
----
-
-## The Trust Ledger
-
-Every session has a trust balance. This determines whether the user can lean on your outputs without second-guessing them — which determines speed.
-
-| Deposits (earn trust → enable speed) | Withdrawals (trust tax → force verification overhead) |
-|--------------------------------------|------------------------------------------------------|
-| Verified claim with inline evidence | Any "should work" used without running the gate |
-| Finding a failure before the user does | Fix that doesn't address root cause |
-| `"I don't know — dispatching subagent"` | Empty output treated as success |
-| Delivering exactly what was committed | Completion claim followed by "oh, also there's X" |
-| Inline output matches what was stated | Expressing satisfaction before running commands |
-
-**High trust = user acts on outputs directly. Low trust = user re-runs every command themselves.**
-
-Every withdrawal forces the user into verification mode for the rest of the session. It is not the individual mistake that costs — it is losing the ability to move fast.
-
----
-
-## Common Failure Modes
-
-| Claim | Requires | Not Sufficient |
-|-------|----------|----------------|
-| "Tests pass" | Test command output: 0 failures | Previous run, "should pass", CI green |
-| "Build succeeds" | cmake output: exit 0 | Linter passing, "looks right" |
-| "Formatted correctly" | `clang-format --dry-run`: 0 errors + `git diff` inspected | "I ran clang-format" without checking diff |
-| "Bug is fixed" | Test reproducing original bug: passes | Code changed, assumed fixed |
-| "PR is ready" | All three gate commands: pass | Tests passing only |
-| "Feature complete" | Every acceptance criterion verified | Tests passing |
+For Particle-Viewer build and test commands, see `references/PV_VERIFICATION_COMMANDS.md`.
 
 ---
 
@@ -263,7 +143,7 @@ If you find yourself thinking any of the following, you are about to make an unv
 
 ---
 
-## Integration
+## Related Skills
 
 - After debugging: always verify with this skill before claiming the fix worked
 - Before every commit: run the full pre-commit gate
@@ -274,63 +154,10 @@ If you find yourself thinking any of the following, you are about to make an unv
 
 ## Agent Delegation Verification
 
-When a subagent reports that it completed work, **do not propagate its claim without verifying.**
-
-Subagents can:
-- Report success on work that was only partially done
-- Fail silently (exit 0 with no actual file changes)
-- Write to the wrong path (worktree vs. main working tree)
-
-**The delegation verification gate:**
-
-```
-Agent reports: "Done" / "Complete" / "Fixed" / "Committed"
-    ↓
-1. Check VCS diff — do the changes exist?
-   git diff HEAD  OR  git -C [worktree-path] diff HEAD
-    ↓
-2. Verify changes match the stated intent
-   Read the diff — do the files changed match what was requested?
-    ↓
-3. Run verification commands on the output
-   cmake --build build && ./build/tests/ParticleViewerTests
-    ↓
-4. ONLY THEN claim the subagent's work is complete
-```
-
-✓ All steps passed → claim the subagent's work is complete
-✗ Any step failed → do not relay the completion claim; investigate and fix before claiming done
-
-**Gate rule:** An agent's "Done" claim is a hypothesis. Your verification makes it a fact.
-
-| Agent claim | Your response |
-|-------------|---------------|
-| "I committed [X]" | `git log --oneline -5` — does the commit exist? |
-| "I updated the file" | `git diff HEAD [file]` — are the changes present? |
-| "All tests pass" | Run `./build/tests/ParticleViewerTests` yourself |
-| "I created the skill" | `ls .github/skills/[skill-name]/SKILL.md` — does it exist? |
-
-**Never relay a subagent's completion claim to the user without first running this gate.**
+When a subagent reports completion, do not propagate its claim without verifying. Subagents can report success on partial work, fail silently, or write to the wrong path. See `references/DELEGATION_GATE.md` for the full delegation verification gate.
 
 ---
 
 ## Research and Evaluation Gate
 
-Before claiming any test result, evaluation finding, or research conclusion is valid, answer these three questions. If any answer is no — stop. The result is not valid.
-
-```
-BEFORE claiming any test result or evaluation finding:
-1. BASELINE: Is there a control condition? What does the system do WITHOUT the treatment?
-2. VALIDITY: Does the test measure what it claims to measure — or only that the subject can follow instructions directly in front of it?
-3. SKEPTIC: Has a Skeptic reviewed the test design BEFORE results were interpreted?
-   If NO: dispatch a Skeptic now. Do not interpret results from an unreviewed design.
-```
-
-| Research claim | Requires | Not sufficient |
-|---|---|---|
-| "Model follows skill gate" | Control run (no skill) showing gate violation + treatment run showing gate compliance | Treatment run alone |
-| "Skill content causes behavior change" | Control + treatment + placebo (same-length irrelevant doc) | Control + treatment only |
-| "Test methodology is valid" | Skeptic review before agents dispatched | Skeptic review after results collected |
-| "Gate compliance confirmed" | Tool-call telemetry showing Skill tool invoked first | Announcement text in output alone |
-
-**This gate is not only for software tests.** It applies to any investigation where you are drawing a conclusion from observed behavior — including agent runs, manual experiments, and informal evaluations.
+For research and evaluation methodology, see `references/RESEARCH_GATE.md`. (Domain note: this gate covers test design and scientific method.)

--- a/.github/skills/verification-before-completion/SKILL.md
+++ b/.github/skills/verification-before-completion/SKILL.md
@@ -102,6 +102,8 @@ Evidence must be **inline**, not referenced:
 ❌ `"I ran the tests and they passed."`  
 ✅ `"Ran <project-test-runner>: **247 passed, 0 failures.** [exit 0]"`
 
+See `references/HONESTY_PATTERNS.md` for why "should work" is banned, process language alternatives, and the 4-Cores final integrity check.
+
 ---
 
 For Particle-Viewer build and test commands, see `references/PV_VERIFICATION_COMMANDS.md`.

--- a/.github/skills/verification-before-completion/references/DELEGATION_GATE.md
+++ b/.github/skills/verification-before-completion/references/DELEGATION_GATE.md
@@ -1,3 +1,5 @@
+# Agent Delegation Gate
+
 ## Agent Delegation Verification
 
 When a subagent reports that it completed work, **do not propagate its claim without verifying.**
@@ -19,7 +21,7 @@ Agent reports: "Done" / "Complete" / "Fixed" / "Committed"
    Read the diff — do the files changed match what was requested?
     ↓
 3. Run verification commands on the output
-   cmake --build build && ./build/tests/ParticleViewerTests
+   Run the project verification commands (see `references/PV_VERIFICATION_COMMANDS.md`)
     ↓
 4. ONLY THEN claim the subagent's work is complete
 ```

--- a/.github/skills/verification-before-completion/references/DELEGATION_GATE.md
+++ b/.github/skills/verification-before-completion/references/DELEGATION_GATE.md
@@ -1,0 +1,39 @@
+## Agent Delegation Verification
+
+When a subagent reports that it completed work, **do not propagate its claim without verifying.**
+
+Subagents can:
+- Report success on work that was only partially done
+- Fail silently (exit 0 with no actual file changes)
+- Write to the wrong path (worktree vs. main working tree)
+
+**The delegation verification gate:**
+
+```
+Agent reports: "Done" / "Complete" / "Fixed" / "Committed"
+    ↓
+1. Check VCS diff — do the changes exist?
+   git diff HEAD  OR  git -C [worktree-path] diff HEAD
+    ↓
+2. Verify changes match the stated intent
+   Read the diff — do the files changed match what was requested?
+    ↓
+3. Run verification commands on the output
+   cmake --build build && ./build/tests/ParticleViewerTests
+    ↓
+4. ONLY THEN claim the subagent's work is complete
+```
+
+✓ All steps passed → claim the subagent's work is complete
+✗ Any step failed → do not relay the completion claim; investigate and fix before claiming done
+
+**Gate rule:** An agent's "Done" claim is a hypothesis. Your verification makes it a fact.
+
+| Agent claim | Your response |
+|-------------|---------------|
+| "I committed [X]" | `git log --oneline -5` — does the commit exist? |
+| "I updated the file" | `git diff HEAD [file]` — are the changes present? |
+| "All tests pass" | Run `./build/tests/ParticleViewerTests` yourself |
+| "I created the skill" | `ls .github/skills/[skill-name]/SKILL.md` — does it exist? |
+
+**Never relay a subagent's completion claim to the user without first running this gate.**

--- a/.github/skills/verification-before-completion/references/HONESTY_PATTERNS.md
+++ b/.github/skills/verification-before-completion/references/HONESTY_PATTERNS.md
@@ -1,0 +1,32 @@
+# Verification Honesty Patterns
+
+## 4 Cores Final Check
+
+The verification gate confirms **Results** — tests pass, build succeeds. But it cannot confirm the first three cores. Run this check *after* the gate, before claiming done.
+
+| Core | Question | What it catches |
+|------|----------|-----------------|
+| **Integrity** | Does the implementation match exactly what was committed — no more, no less? | Scope creep, partial delivery, undisclosed limitations |
+| **Intent** | Am I solving the stated problem, or the comfortable version of it? | Solving an easier adjacent problem; avoiding the hard requirement |
+| **Capabilities** | Is this the right solution, or just the first one that worked? | Technically-passing implementation that creates future maintenance burden |
+| **Results** | Can I show verifiable inline evidence? | Covered by the gate above — cite it explicitly |
+
+**Failing any core = do not claim done. Resolve the gap first.**
+
+The Results core is covered by the verification commands above. The first three are quality checks that evidence alone cannot catch — a test suite can pass while the wrong problem is solved perfectly.
+
+**Worst common violation — Intent:** An agent solves the easy part of a requirement (the part it's comfortable with) and presents it as the full solution. The tests pass. The build is clean. The requirement is not met. The 4 Cores check catches this by asking "did I solve what was asked, or what was convenient?"
+
+## Why "Should Work" Is Banned
+
+"Should work" combines the tone of having verified with the reality of not having verified. It is undetectable false confidence. A user reading "should work" cannot tell whether you ran the gate or not. Replace it with either:
+- Evidence: `"Ran [command]: [output]. It works."`
+- Honest uncertainty: `"Haven't verified yet — running the gate now."`
+
+## Process Language (Always Available)
+
+Use freely when verification hasn't been run:
+- `"Running verification now..."`
+- `"Haven't run the gate yet — doing that now"`
+- `"Identified likely cause — confirming before claiming fix"`
+- `"Uncertain about X — dispatching subagent to confirm"`

--- a/.github/skills/verification-before-completion/references/PV_DONE_DEFINITION.md
+++ b/.github/skills/verification-before-completion/references/PV_DONE_DEFINITION.md
@@ -1,3 +1,5 @@
+# Particle-Viewer Done Definition
+
 For this project (a desktop application, not a deployed service), the equivalent stages are:
 - "Locally verified" — builds + tests pass after the change
 - "Gate passed" — full pre-commit gate (build + tests + format + diff review) completed

--- a/.github/skills/verification-before-completion/references/PV_DONE_DEFINITION.md
+++ b/.github/skills/verification-before-completion/references/PV_DONE_DEFINITION.md
@@ -1,0 +1,7 @@
+For this project (a desktop application, not a deployed service), the equivalent stages are:
+- "Locally verified" — builds + tests pass after the change
+- "Gate passed" — full pre-commit gate (build + tests + format + diff review) completed
+- "Committed" — code committed with passing gate
+- **"Done"** — committed, PR merged, branch clean
+
+Use stage vocabulary. Never use "Done" for a stage that is not the final stage.

--- a/.github/skills/verification-before-completion/references/PV_VERIFICATION_COMMANDS.md
+++ b/.github/skills/verification-before-completion/references/PV_VERIFICATION_COMMANDS.md
@@ -1,3 +1,5 @@
+# Particle-Viewer Verification Commands
+
 ## The Verification Commands
 
 > **Note (Particle-Viewer specific):** The commands below use this project's build system and test runner. Adapt `cmake --build build`, `./build/tests/ParticleViewerTests`, and the `find src tests` glob for your own project.

--- a/.github/skills/verification-before-completion/references/PV_VERIFICATION_COMMANDS.md
+++ b/.github/skills/verification-before-completion/references/PV_VERIFICATION_COMMANDS.md
@@ -1,0 +1,18 @@
+## The Verification Commands
+
+> **Note (Particle-Viewer specific):** The commands below use this project's build system and test runner. Adapt `cmake --build build`, `./build/tests/ParticleViewerTests`, and the `find src tests` glob for your own project.
+
+```bash
+# Build
+cmake --build build
+
+# Tests
+./build/tests/ParticleViewerTests
+
+# Format check
+find src tests -name "*.cpp" -o -name "*.hpp" | xargs clang-format --dry-run -Werror
+
+# Full pre-commit gate (run all three before every commit)
+find src tests -name "*.cpp" -o -name "*.hpp" | xargs clang-format -i
+cmake --build build && ./build/tests/ParticleViewerTests
+```

--- a/.github/skills/verification-before-completion/references/RESEARCH_GATE.md
+++ b/.github/skills/verification-before-completion/references/RESEARCH_GATE.md
@@ -1,0 +1,20 @@
+## Research and Evaluation Gate
+
+Before claiming any test result, evaluation finding, or research conclusion is valid, answer these three questions. If any answer is no — stop. The result is not valid.
+
+```
+BEFORE claiming any test result or evaluation finding:
+1. BASELINE: Is there a control condition? What does the system do WITHOUT the treatment?
+2. VALIDITY: Does the test measure what it claims to measure — or only that the subject can follow instructions directly in front of it?
+3. SKEPTIC: Has a Skeptic reviewed the test design BEFORE results were interpreted?
+   If NO: dispatch a Skeptic now. Do not interpret results from an unreviewed design.
+```
+
+| Research claim | Requires | Not sufficient |
+|---|---|---|
+| "Model follows skill gate" | Control run (no skill) showing gate violation + treatment run showing gate compliance | Treatment run alone |
+| "Skill content causes behavior change" | Control + treatment + placebo (same-length irrelevant doc) | Control + treatment only |
+| "Test methodology is valid" | Skeptic review before agents dispatched | Skeptic review after results collected |
+| "Gate compliance confirmed" | Tool-call telemetry showing Skill tool invoked first | Announcement text in output alone |
+
+**This gate is not only for software tests.** It applies to any investigation where you are drawing a conclusion from observed behavior — including agent runs, manual experiments, and informal evaluations.

--- a/.github/skills/verification-before-completion/references/RESEARCH_GATE.md
+++ b/.github/skills/verification-before-completion/references/RESEARCH_GATE.md
@@ -1,3 +1,5 @@
+# Research and Evaluation Gate
+
 ## Research and Evaluation Gate
 
 Before claiming any test result, evaluation finding, or research conclusion is valid, answer these three questions. If any answer is no — stop. The result is not valid.

--- a/.github/skills/verification-before-completion/references/VERIFICATION_THEORY.md
+++ b/.github/skills/verification-before-completion/references/VERIFICATION_THEORY.md
@@ -1,3 +1,5 @@
+# Verification Theory
+
 ## Combine Verification Instruments
 
 **No single verification technique removes more than ~70% of defects.** (Capers Jones research, cited in McConnell's *Code Complete*.)

--- a/.github/skills/verification-before-completion/references/VERIFICATION_THEORY.md
+++ b/.github/skills/verification-before-completion/references/VERIFICATION_THEORY.md
@@ -1,0 +1,54 @@
+## Combine Verification Instruments
+
+**No single verification technique removes more than ~70% of defects.** (Capers Jones research, cited in McConnell's *Code Complete*.)
+
+| Technique | Defect removal efficiency |
+|-----------|--------------------------|
+| Unit testing alone | 30–40% |
+| Code inspection/review | 45–70% |
+| **Both combined** | **>90%** |
+
+The IBM Cleanroom result: formal inspections achieved <0.1 defects/KLOC vs. industry average 15–50.
+
+**The implication:** "Tests pass" with no additional review still has a statistically likely defect rate of 30–70%. Tests catch execution-time defects. Code review catches logical, requirements, and interface defects that tests cannot surface.
+
+**Gate for this project:**
+
+Before claiming any PR ready:
+1. **Tests pass** — execution-time defects caught
+2. **Diff reviewed** — logical and interface defects caught (`git diff` read hunk by hunk)
+3. **Format verified** — `clang-format --dry-run` clean
+4. **Scope verified** — changes touch only what the task required; no accidental changes
+
+**Rationalization:** "Tests pass — I'm done." Counter: no single technique removes >70% of defects. Tests + diff review is the minimum combined instrument set.
+
+---
+
+## The Trust Ledger
+
+Every session has a trust balance. This determines whether the user can lean on your outputs without second-guessing them — which determines speed.
+
+| Deposits (earn trust → enable speed) | Withdrawals (trust tax → force verification overhead) |
+|--------------------------------------|------------------------------------------------------|
+| Verified claim with inline evidence | Any "should work" used without running the gate |
+| Finding a failure before the user does | Fix that doesn't address root cause |
+| `"I don't know — dispatching subagent"` | Empty output treated as success |
+| Delivering exactly what was committed | Completion claim followed by "oh, also there's X" |
+| Inline output matches what was stated | Expressing satisfaction before running commands |
+
+**High trust = user acts on outputs directly. Low trust = user re-runs every command themselves.**
+
+Every withdrawal forces the user into verification mode for the rest of the session. It is not the individual mistake that costs — it is losing the ability to move fast.
+
+---
+
+## Common Failure Modes
+
+| Claim | Requires | Not Sufficient |
+|-------|----------|----------------|
+| "Tests pass" | Test command output: 0 failures | Previous run, "should pass", CI green |
+| "Build succeeds" | cmake output: exit 0 | Linter passing, "looks right" |
+| "Formatted correctly" | `clang-format --dry-run`: 0 errors + `git diff` inspected | "I ran clang-format" without checking diff |
+| "Bug is fixed" | Test reproducing original bug: passes | Code changed, assumed fixed |
+| "PR is ready" | All three gate commands: pass | Tests passing only |
+| "Feature complete" | Every acceptance criterion verified | Tests passing |


### PR DESCRIPTION
## Summary

Compresses 8 over-budget skill SKILL.md files by moving body content verbatim into `references/` subdirectories. All messaging is preserved exactly — no rewrites, no rephrasing.

## Skills compressed

| Skill | New reference files | Notable |
|-------|---------------------|---------|
| `subagent-driven-development` | MODEL_SELECTION.md, REVIEW_PROTOCOL.md | Git Worktrees section deduped (owned by using-git-worktrees) |
| `session-bootstrap` | SKILL_DISPATCH_TABLE.md, EXTENDED_CHECKS.md | Dispatch table and extended checks moved |
| `verification-before-completion` | VERIFICATION_THEORY.md, PV_DONE_DEFINITION.md, PV_VERIFICATION_COMMANDS.md, DELEGATION_GATE.md, RESEARCH_GATE.md, HONESTY_PATTERNS.md | 6 reference files |
| `testing` | TESTING_EXAMPLES.md, PV_TEST_CONVENTIONS.md | AAA rules deduped; orphaned reference files re-linked |
| `execution` | EXECUTION_PATTERNS.md | 8 sections moved; MIWMIRMIF pointer added |
| `code-quality` | CPP_TOOLCHAIN.md, CODE_SMELLS.md, NAMING_TABLES.md, FORMATTING_RULES.md, REVIEW_CHECKLIST.md, INVOCATION.md | 6 reference files |
| `session-postmortem` | POSTMORTEM_STRUCTURE.md, BATCH_ANALYSIS.md | 71% SKILL.md reduction |
| `user-story-generator` | STORY_TEMPLATE.md, INVEST_GUIDE.md, INVEST_FRAMEWORK.md (pre-existing), CONVERSATION_SCRIPTS.md, PV_PROJECT_CONTEXT.md | Path violations corrected |

## Constraints respected

- **Verbatim moves only** — no rewrites or rephrasing
- **Inline pointers at removal site** — each moved section replaced by a `See `references/X.md` for …` line at the exact location
- **All cross-skill paths replaced** with prose skill names in backticks
- **All reference files** have `#` H1 headings
- **5 gate elements preserved** in every SKILL.md body (Iron Law, Announcement line, BEFORE PROCEEDING gate, Rationalization Prevention table, Red Flags→STOP)

## Review process

Each skill went through:
1. Stage 1 spec-compliance review (dispatch per todo)
2. Stage 2 code-quality review (dispatch per todo)
3. Fix rounds as needed until APPROVE / APPROVE WITH NITS with all nits resolved

All 8 skills have clean Stage 2 approvals before merge.