### PR TITLE
feat(cache): COM prefetch & sliding-window frame cache

### DIFF
--- a/.github/agents/spec-compliance-reviewer.md
+++ b/.github/agents/spec-compliance-reviewer.md
@@ -53,6 +53,7 @@ Do not ask the caller to provide a diff. Derive it yourself.
 - Do NOT suggest improvements or refactoring
 - Do NOT praise the implementation
 - "Tests pass" is not evidence that requirements are met — evaluate the implementation, not the test results
+- For any class whose state is displayed in the UI: verify each UI-displayed field has a traceable public accessor (class method → `MenuState` field → menu render call). A UI acceptance criterion without a class API path is a spec gap — report it as MISSING, not FULL.
 
 ### Duplication Check for Extension Tasks
 

--- a/.github/skills/cpp-patterns/SKILL.md
+++ b/.github/skills/cpp-patterns/SKILL.md
@@ -138,6 +138,7 @@ DRY means every piece of **knowledge** has a single authoritative representation
 
 - **DRY violation signal:** "If this constant changes, I need to update it in N places."
 - **False DRY signal:** "These two functions look the same." Looks are not knowledge. Check whether they represent the same concept before extracting.
+- **Interface exposure signal:** If a call site derives a value from an interface (e.g., computes `frame_count * element_size` to get bytes), and the derivation is the same everywhere, add the derived quantity as a virtual method on the interface. The concrete class is the single source of truth; callers never re-derive it.
 
 ---
 

--- a/.github/skills/cpp-safety/SKILL.md
+++ b/.github/skills/cpp-safety/SKILL.md
@@ -36,6 +36,21 @@ Throwing from a destructor during stack unwinding calls `std::terminate` — no 
 
 If the constructor acquires resource A then throws while acquiring resource B, A leaks — the destructor is never called on a partially-constructed object. Each acquisition must be handed to its own scope-bound guard before the next acquisition begins.
 
+**When acquisition happens in a factory method (not a constructor) using raw pointers:** if `unique_ptr` cannot be used (e.g., the pointer is a member reset by a helper method), wrap the second `new` in try-catch — delete and null the first pointer before rethrowing:
+
+```cpp
+void createResources() {
+    executor_ = new Executor();
+    try {
+        cache_ = new Cache(*executor_);
+    } catch (...) {
+        delete executor_;
+        executor_ = nullptr;
+        throw;
+    }
+}
+```
+
 See the `cpp-patterns` skill for ownership patterns and OpenGL-specific examples.
 
 ---

--- a/.github/skills/execution/SKILL.md
+++ b/.github/skills/execution/SKILL.md
@@ -93,7 +93,7 @@ If you catch yourself thinking any of these:
 
 ## Prove It Before You Ship It
 
-**REQUIRED: Use the `verification-before-completion` skill.**
+**REQUIRED: Load and invoke the `verification-before-completion` skill** — this means calling the `skill` tool, not referencing the skill name in text. A completion claim made without a `skill.invoked` event for `verification-before-completion` is a protocol violation. Runtime user-visible bugs found after a "fully implemented" claim are the direct cost of skipping this load.
 
 Before claiming any task done:
 - Diff: `git --no-pager diff --staged` — read every hunk for accidental changes. **Applies to ALL file types including documentation. Documentation commits are not exempt.**
@@ -207,6 +207,7 @@ For the domain-to-skill dispatch lookup, see `references/EXECUTION_PATTERNS.md`.
 | "I'm close to the end, I'll skip the Skeptic for this todo" | End-of-plan todos are the most likely to drift from the original scope. The Skeptic Agent is mandatory regardless of position in the plan. |
 | "Inline nit fix is trivial, no review needed" | Inline fixes are unverified by default. If the fix is a structural change (heading level, path format, sentence replacement), dispatch a re-review or apply only to content you can verify in the same view call. |
 | "After a rate limit, I can resume dispatching immediately — my last checkpoint shows what was in flight" | A rate limit severs the agent's awareness of what agents completed, errored, or were interrupted. Dispatch a validation-only batch first and wait for the result before dispatching any continuation agents. |
+| "User correction deferred 'for the self-review later' — I'll remember it" | Memory does not survive rate limits, context compactions, or session summaries. File deferred corrections immediately as a SQL todo or session note. "I'll remember" is not a commitment mechanism. |
 
 ---
 

--- a/.github/skills/self-evaluation/references/LESSONS_LEARNED_PATTERNS.md
+++ b/.github/skills/self-evaluation/references/LESSONS_LEARNED_PATTERNS.md
@@ -306,6 +306,72 @@ Concrete examples of lessons captured from past sessions and how they were incor
 
 ---
 
+### Test Names Must Describe Behavior Proven, Not Return Value (PR #112, round 2)
+
+**Problem:** `GetCOM_ValidFile_Frame1_ReturnsTrue` described the return value, not what property was being verified. Code review renamed it to `GetCOM_ValidFile_Frame1_SeekIsAbsolute` — the test was specifically checking that `SEEK_SET` (absolute seek) was used.
+
+**Lesson:** The `_ExpectedResult` segment of `UnitName_StateUnderTest_ExpectedResult` must encode the *invariant or property proven*, not just the return value. `_SeekIsAbsolute` answers "what holds?"; `_ReturnsTrue` answers "what came back?" — the latter masks what the test is actually verifying.
+
+**Added to:** `testing` skill → Naming Convention section
+
+---
+
+### Failure-Path Tests Must Assert Output Parameters Are Unchanged (PR #112, round 2)
+
+**Problem:** Failure-path tests for `getCOM()` only called `EXPECT_FALSE(...)` without asserting that the output parameter `value` was unchanged. A regression that modified `value` even on failure would pass all tests.
+
+**Lesson:** For any function returning bool/error-code: in failure-path tests, always assert output parameters remain at their initial value (`EXPECT_EQ(outValue, glm::vec3(0.f))` after `EXPECT_FALSE(...)`). Initialize output params to a known value in Arrange so the Assert is meaningful.
+
+**Added to:** `testing` skill → Self-Review Checklist
+
+---
+
+### Two-Step Factory Method Exception Safety (PR #112, round 2)
+
+**Problem:** `createCOMInfrastructure()` allocated `com_executor_` then `com_cache_`. If `COMCache` constructor threw, `com_executor_` leaked because the destructor was never called (method-level allocation, not a constructor).
+
+**Lesson:** When a factory method (not a constructor) sequentially allocates two raw pointers, wrap the second `new` in try-catch: delete and null the first pointer before rethrowing. This is the raw-pointer equivalent of scope-bound guards when `unique_ptr` is impractical.
+
+**Added to:** `cpp-safety` skill → Constructor Rule section
+
+---
+
+### Expose Derived Quantities on the Interface to Prevent DRY Violations (PR #112, round 2)
+
+**Problem:** `viewer_app.cpp` computed `bytes_used = frame_cache_->capacity() * particles_per_frame * sizeof(glm::vec4)` — duplicating `FrameCache`'s internal `frame_size_bytes` formula. If per-particle data layout changed, the call site would silently produce wrong values.
+
+**Lesson:** When a call site derives a value from an interface (counts, sizes, compound formulas), add the derived quantity as a virtual method on the interface. The concrete class is the single source of truth; callers receive the value without re-deriving it. Signal: "if the formula changes, I need to update it in N places."
+
+**Added to:** `cpp-patterns` skill → DRY section
+
+**Problem:** `FrameCache` pending-cap test used `EXPECT_LE(callCount, window)`. The count is deterministically equal to `window` — using LE hid the fact that a regression (under-enqueue) would still pass.
+
+**Lesson:** Use `EXPECT_EQ` when the value is deterministic. `EXPECT_LE`/`EXPECT_GE` are for inherently non-deterministic values (timing, OS scheduling). An overly lenient bound masks regressions.
+
+**Added to:** `testing` skill → `TESTING_EXAMPLES.md` → Incorrect Examples
+
+---
+
+### Binary File Tests: Record Count Must Cover Target Frame (PR #112)
+
+**Problem:** `COMFileProvider_FrameIndexMismatch_ReturnsFalse` was written with a single-record file and a request for frame 1. `fseek` to frame 1 went past EOF, so `fread` returned 0 (truncation), exercising the wrong branch.
+
+**Lesson:** When writing a binary file test that seeks to frame N, write at least N+1 records so `fseek` lands within the file and `fread` actually reads the target record. A single-record file will always produce a truncation result for any frame > 0.
+
+**Added to:** `testing` skill → `TESTING_EXAMPLES.md` → Incorrect Examples
+
+---
+
+### Full Docstring Rewrite Required When void→bool (PR #112)
+
+**Problem:** After changing `getCOM()` from void to bool, the docstring was patched to mention the return value, but the first sentence still said "caller must call checkCOM() first" while a later sentence said "no extra checkCOM round-trip". The two sentences contradicted each other.
+
+**Lesson:** When changing a function's calling contract (especially void→bool), rewrite the *entire* docstring — don't patch it. The new contract (all false-return cases, what the caller need not do) renders the old docstring structurally incorrect and patching a structurally wrong docstring still leaves it wrong.
+
+**Added to:** Self-evaluation skill (this file)
+
+---
+
 ## Quick Reference: Where to Add Lessons
 
 Use this for fast question-based lookup — "my lesson is about X, where does it go?" For formal classification with concrete examples, use the Category Classification Table below.

--- a/.github/skills/self-evaluation/references/LESSONS_LEARNED_PATTERNS.md
+++ b/.github/skills/self-evaluation/references/LESSONS_LEARNED_PATTERNS.md
@@ -276,6 +276,36 @@ Concrete examples of lessons captured from past sessions and how they were incor
 
 **Added to:** `code-quality` skill → Step 7: Adding a Feature / Fixing a Bug
 
+### EXPECT_EQ Over EXPECT_LE for Deterministic Counts (PR #112)
+
+**Problem:** `FrameCache` pending-cap test used `EXPECT_LE(callCount, window)`. The count is deterministically equal to `window` — using LE hid the fact that a regression (under-enqueue) would still pass.
+
+**Lesson:** Use `EXPECT_EQ` when the value is deterministic. `EXPECT_LE`/`EXPECT_GE` are for inherently non-deterministic values (timing, OS scheduling). An overly lenient bound masks regressions.
+
+**Added to:** `testing` skill → `TESTING_EXAMPLES.md` → Incorrect Examples
+
+---
+
+### Binary File Tests: Record Count Must Cover Target Frame (PR #112)
+
+**Problem:** `COMFileProvider_FrameIndexMismatch_ReturnsFalse` was written with a single-record file and a request for frame 1. `fseek` to frame 1 went past EOF, so `fread` returned 0 (truncation), exercising the wrong branch.
+
+**Lesson:** When writing a binary file test that seeks to frame N, write at least N+1 records so `fseek` lands within the file and `fread` actually reads the target record. A single-record file will always produce a truncation result for any frame > 0.
+
+**Added to:** `testing` skill → `TESTING_EXAMPLES.md` → Incorrect Examples
+
+---
+
+### Full Docstring Rewrite Required When void→bool (PR #112)
+
+**Problem:** After changing `getCOM()` from void to bool, the docstring was patched to mention the return value, but the first sentence still said "caller must call checkCOM() first" while a later sentence said "no extra checkCOM round-trip". The two sentences contradicted each other.
+
+**Lesson:** When changing a function's calling contract (especially void→bool), rewrite the *entire* docstring — don't patch it. The new contract (all false-return cases, what the caller need not do) renders the old docstring structurally incorrect and patching a structurally wrong docstring still leaves it wrong.
+
+**Added to:** Self-evaluation skill (this file)
+
+---
+
 ## Quick Reference: Where to Add Lessons
 
 Use this for fast question-based lookup — "my lesson is about X, where does it go?" For formal classification with concrete examples, use the Category Classification Table below.

--- a/.github/skills/session-bootstrap/SKILL.md
+++ b/.github/skills/session-bootstrap/SKILL.md
@@ -137,6 +137,7 @@ behavior is habitual, not conditional.
 - Starting implementation when SQL has pending todos from a prior session without dispatching Skeptic — **STOP. Dispatch Skeptic before the first implementation step.**
 - Starting to code before reading the required skill — **STOP. Load the skill now. Do not write one line first.**
 - Skipping the skill-load announcement — **STOP. State "I am using the [skill] skill to [purpose]." No skip.**
+- Announced "I am using skill X" without invoking the skill tool in the same response — **STOP. An announcement without a matching `skill.invoked` event is a false statement. The announcement and the `skill` tool call MUST occur in the same turn. Load the skill now.**
 - Finishing a session without running `self-evaluation` — **STOP. Read `.github/skills/self-evaluation/SKILL.md` now.**
 - Treating the "On Finish" steps as optional — **STOP. They are mandatory. Execute every step.**
 - Saying "I remember the skill content" — **STOP. Memory degrades. Skills update. Load fresh every session.**

--- a/.github/skills/subagent-driven-development/SKILL.md
+++ b/.github/skills/subagent-driven-development/SKILL.md
@@ -183,6 +183,7 @@ These thoughts mean stop immediately:
 | "I remember that..." | Memory is always unverified — dispatch |
 | "Based on how it usually works..." | Dispatch to confirm the actual behavior |
 | "Dispatching a file-modifying agent without creating a worktree first" | STOP. Create the worktree and load `using-git-worktrees` before dispatch. |
+| "About to create a worktree without `using-git-worktrees` loaded" | STOP. Load `using-git-worktrees` first — every time, without exception. The session-bootstrap On Start table maps "Parallel agent work / A/B testing" to this skill. Creating worktrees without it is a retroactive-load violation. |
 | "A template exists but I'll build the prompt manually" | STOP. Use the pre-built template from `.github/agents/`. Do not reinvent it. |
 
 ---

--- a/.github/skills/systematic-debugging/SKILL.md
+++ b/.github/skills/systematic-debugging/SKILL.md
@@ -65,7 +65,9 @@ Each phase MUST be completed in order.
 
 ### Phase 0: Write the Problem Down First
 
-Before touching any tool, write one precise sentence describing the failure: what is failing, what was expected, and what actually happened. Vague problem statements produce vague investigations. If you cannot write the sentence, you do not yet understand the problem well enough to investigate it.
+**First: verify your test runner CWD.** Run `pwd` and confirm it matches the required execution directory (e.g., `…/build` for `./tests/ParticleViewerTests`). CWD mismatch is the most common source of false test failures — a failing test caused by wrong CWD is not a regression and requires no fix.
+
+Before touching any other tool, write one precise sentence describing the failure: what is failing, what was expected, and what actually happened. Vague problem statements produce vague investigations. If you cannot write the sentence, you do not yet understand the problem well enough to investigate it.
 
 See `references/DEBUGGING_TACTICS.md` for the full Feynman Algorithm and structured tactic selection.
 
@@ -156,6 +158,7 @@ If you find yourself thinking any of the following, **STOP and return to Phase 1
 | "The test is flaky, just rerun it" | Flaky = non-determinism = root cause needed. |
 | "One more fix attempt" (after 2+ failures) | 3+ failures = architectural problem. Question the approach. |
 | "I found it — patching it now" | "Debug" means investigate and report. It does not mean fix. Present findings, wait for instruction. |
+| "I already started debugging before loading this skill — I'll use it from here" | Retroactive skill load violates the read-before-act Iron Law. Any investigation performed before loading this skill is tainted by unverified assumptions. **STOP. Restart from Phase 0 with this skill active.** |
 
 ---
 

--- a/.github/skills/testing/SKILL.md
+++ b/.github/skills/testing/SKILL.md
@@ -58,6 +58,8 @@ Use format: `UnitName_StateUnderTest_ExpectedResult`
 Examples:
 - `MoveForward_IncreasesZPosition`
 
+**`_ExpectedResult` must describe the behavior or invariant proven — not the return value.** The result name should answer "what property holds?" not "what did the call return?". `_SeekIsAbsolute` is better than `_ReturnsTrue`; `_CacheMissCallsReader` is better than `_ReturnsValue`.
+
 See `references/TESTING_EXAMPLES.md` for PV naming examples.
 
 For PV-specific test patterns (Camera, SettingsIO examples), test double taxonomy, file organization, and test size taxonomy, see `references/PV_TEST_CONVENTIONS.md`. For visual regression, see the `visual-regression-testing` skill.
@@ -79,6 +81,7 @@ Before presenting tests, verify:
 - [ ] Resource cleanup: GL objects deleted in destructors/cleanup, check for leaks
 - [ ] Tests compile and pass
 - [ ] For any class whose state feeds the UI: each UI-displayed field has a unit test verifying the public accessor returns the correct value (not just that the field is set internally)
+- [ ] For functions that return bool/error-code: failure-path tests assert output parameters are unchanged (e.g., `EXPECT_EQ(outValue, initialValue)` after `EXPECT_FALSE(call(..., &outValue))`)
 - [ ] For visual regression tests: see visual-regression-testing skill checklist
 
 ✓ All met → proceed

--- a/.github/skills/testing/SKILL.md
+++ b/.github/skills/testing/SKILL.md
@@ -78,6 +78,7 @@ Before presenting tests, verify:
 - [ ] Group related configuration into structs/POCOs instead of flat variables
 - [ ] Resource cleanup: GL objects deleted in destructors/cleanup, check for leaks
 - [ ] Tests compile and pass
+- [ ] For any class whose state feeds the UI: each UI-displayed field has a unit test verifying the public accessor returns the correct value (not just that the field is set internally)
 - [ ] For visual regression tests: see visual-regression-testing skill checklist
 
 ✓ All met → proceed

--- a/.github/skills/testing/references/TESTING_EXAMPLES.md
+++ b/.github/skills/testing/references/TESTING_EXAMPLES.md
@@ -227,6 +227,47 @@ TEST(ImageTest, PixelVector_Resizes)
 
 **Fix:** Only test YOUR code — wrapper logic, integration, or behavior you own.
 
+### ❌ EXPECT_LE When the Value Is Deterministic
+
+```cpp
+// BAD: LE masks regressions where the code under-enqueues
+EXPECT_LE(callCount, window);  // passes even if callCount is 0 or window-1
+```
+
+**Fix:** Use `EXPECT_EQ` when the value is deterministic. Reserve `EXPECT_LE`/`EXPECT_GE` only for inherently non-deterministic results (e.g., timing, OS scheduling).
+
+```cpp
+// GOOD: fails immediately if cap logic changes
+EXPECT_EQ(callCount, window);
+```
+
+### ❌ Binary File Test Missing Required Record Count
+
+When testing that a binary reader correctly handles a frame-N seek, a file with fewer than N+1 records causes `fseek` to go past EOF, so `fread` returns 0 (EOF/truncated), not a record with the wrong field. This means the test ends up exercising the truncation branch instead of the intended branch (e.g., field mismatch):
+
+```cpp
+// BAD: single-record file; seeking to frame=1 goes past EOF → fread returns 0
+// (tests truncation, not the intended field-mismatch path)
+FILE* f = fopen(path.c_str(), "wb");
+float r0[4] = {1.0f, 2.0f, 3.0f, 0.0f};  // frame 0 only
+fwrite(r0, sizeof(float), 4, f);
+fclose(f);
+getCOM(/*frame=*/1, out);  // seeks to byte 16 — past EOF
+```
+
+**Fix:** Write N+1 records so `fseek` lands within the file and `fread` succeeds:
+
+```cpp
+// GOOD: two records; seeking to frame=1 reads the second record's w field
+FILE* f = fopen(path.c_str(), "wb");
+float r0[4] = {0, 0, 0, 0};        // padding for frame 0
+float r1[4] = {1.0f, 2.0f, 3.0f, 99.0f};  // frame 1, w=99 (wrong type to trigger mismatch)
+fwrite(r0, sizeof(float), 4, f);
+fwrite(r1, sizeof(float), 4, f);
+fclose(f);
+getCOM(/*frame=*/1, out);  // reads r1; w=99 ≠ frame=1 → mismatch branch
+```
+
 ### ❌ Vague Test Name
 
 ```cpp

--- a/.github/skills/writing-plans/SKILL.md
+++ b/.github/skills/writing-plans/SKILL.md
@@ -59,6 +59,7 @@ My optimization target: [user's stated outcome], not [convenient proxy]."
 4. Sanity-check: does the plan address every acceptance criterion?
 5. Name known downsides proactively — trade-offs, risks, limitations the user did not ask about
 6. Disclose decision rationale — name alternatives considered and why chosen approach was preferred
+7. **Token budget gate:** If todo count ≥ 8, load `user-story-estimation` and compute the token budget before presenting the plan for approval. A 14-todo epic with a full 3-agent review pipeline consumes ~500K tokens × 42+ dispatches minimum. Compute this upfront — not after 3 rate-limit hits.
 
 ### No-Placeholder Rule
 
@@ -106,6 +107,8 @@ Answer before finalizing any plan. Dispatch a research subagent if you cannot an
 
 ✓ All 5 questions answered with no gaps → proceed to review gate or implementation
 ✗ Any unanswered question or revealed gap → stop, revise the plan, then re-run the gate
+
+**For features with background threads or async state:** answer a 6th question before finalizing: "How will a developer diagnose this at runtime?" If no debug output path exists, add an observability todo before presenting the plan. A feature with invisible async state has no failure-diagnosis path.
 
 For any plan with 2+ todos or an architectural decision, dispatch a review agent before implementation. The routing depends on whether Discovery ran:
 

--- a/src/COMCache.cpp
+++ b/src/COMCache.cpp
@@ -51,17 +51,22 @@ std::optional<glm::vec3> COMCache::getCOM(long frame)
     executor_.enqueue([this, frame]() {
         std::vector<glm::vec4> positions = sio_.readPosBuffer(frame);
 
-        std::lock_guard<std::mutex> lock{mutex_};
-        pending_.erase(frame);
-
         if (positions.empty()) {
             // I/O failure: record in failed_ to prevent infinite re-enqueue.
             // Do NOT cache (0,0,0) — callers keep their previous COM on miss.
+            std::lock_guard<std::mutex> lock{mutex_};
+            pending_.erase(frame);
             failed_.insert(frame);
             return;
         }
 
+        // Compute COM outside the lock so getCOM() and cachedCount() callers
+        // on the render thread are not blocked during the (potentially slow)
+        // mass-weighted computation.
         glm::vec3 com = COMCalculator::computeMassWeightedCOM(std::span<const glm::vec4>(positions), mp_);
+
+        std::lock_guard<std::mutex> lock{mutex_};
+        pending_.erase(frame);
         cache_[frame] = com;
     });
 

--- a/src/COMCache.cpp
+++ b/src/COMCache.cpp
@@ -32,6 +32,11 @@ std::optional<glm::vec3> COMCache::getCOM(long frame)
             return it->second;
         }
 
+        // Permanent I/O failure for this frame: do not re-enqueue.
+        if (failed_.count(frame) > 0) {
+            return std::nullopt;
+        }
+
         // Already enqueued: don't double-enqueue.
         if (pending_.count(frame) > 0) {
             return std::nullopt;
@@ -45,10 +50,18 @@ std::optional<glm::vec3> COMCache::getCOM(long frame)
     // the task inline on the calling thread before returning from enqueue).
     executor_.enqueue([this, frame]() {
         std::vector<glm::vec4> positions = sio_.readPosBuffer(frame);
-        glm::vec3 com = COMCalculator::computeMassWeightedCOM(std::span<const glm::vec4>(positions), mp_);
 
         std::lock_guard<std::mutex> lock{mutex_};
         pending_.erase(frame);
+
+        if (positions.empty()) {
+            // I/O failure: record in failed_ to prevent infinite re-enqueue.
+            // Do NOT cache (0,0,0) — callers keep their previous COM on miss.
+            failed_.insert(frame);
+            return;
+        }
+
+        glm::vec3 com = COMCalculator::computeMassWeightedCOM(std::span<const glm::vec4>(positions), mp_);
         cache_[frame] = com;
     });
 
@@ -71,6 +84,7 @@ void COMCache::clear()
     std::lock_guard<std::mutex> lock{mutex_};
     cache_.clear();
     pending_.clear();
+    failed_.clear();
 }
 
 std::size_t COMCache::cachedCount() const

--- a/src/COMCache.cpp
+++ b/src/COMCache.cpp
@@ -1,0 +1,62 @@
+/*
+ * COMCache.cpp
+ *
+ * Async memoisation of per-frame centre-of-mass values.
+ * See COMCache.hpp for design notes.
+ */
+
+// COMCache.hpp includes <glad/glad.h> before MassParams.hpp → settingsIO.hpp
+// → particle.hpp, so no special ordering is needed here.
+#include "COMCache.hpp"
+
+#include <span>
+
+#include <glm/glm.hpp>
+
+#include "COMCalculator.hpp"
+#include "settingsIO.hpp"
+
+COMCache::COMCache(SettingsIO& sio, MassParams mp, IExecutor& executor)
+    : sio_(sio), mp_(std::move(mp)), executor_(executor)
+{
+}
+
+std::optional<glm::vec3> COMCache::getCOM(long frame)
+{
+    {
+        std::lock_guard<std::mutex> lock{mutex_};
+
+        // Cache hit: return stored value immediately.
+        if (auto it = cache_.find(frame); it != cache_.end()) {
+            return it->second;
+        }
+
+        // Already enqueued: don't double-enqueue.
+        if (pending_.count(frame) > 0) {
+            return std::nullopt;
+        }
+
+        // Mark as pending before releasing the lock.
+        pending_.insert(frame);
+    }
+    // Mutex is NOT held here; the compute task may re-acquire it safely.
+    // This prevents a deadlock when using SynchronousExecutor (which runs
+    // the task inline on the calling thread before returning from enqueue).
+    executor_.enqueue([this, frame]() {
+        std::vector<glm::vec4> positions = sio_.readPosBuffer(frame);
+        glm::vec3 com = COMCalculator::computeMassWeightedCOM(std::span<const glm::vec4>(positions), mp_);
+
+        std::lock_guard<std::mutex> lock{mutex_};
+        pending_.erase(frame);
+        cache_[frame] = com;
+    });
+
+    return std::nullopt;
+}
+
+void COMCache::clear()
+{
+    std::lock_guard<std::mutex> lock{mutex_};
+    cache_.clear();
+    pending_.clear();
+}

--- a/src/COMCache.cpp
+++ b/src/COMCache.cpp
@@ -72,3 +72,9 @@ void COMCache::clear()
     cache_.clear();
     pending_.clear();
 }
+
+std::size_t COMCache::cachedCount() const
+{
+    std::lock_guard<std::mutex> lock{mutex_};
+    return cache_.size();
+}

--- a/src/COMCache.cpp
+++ b/src/COMCache.cpp
@@ -9,6 +9,7 @@
 // → particle.hpp, so no special ordering is needed here.
 #include "COMCache.hpp"
 
+#include <algorithm>
 #include <span>
 
 #include <glm/glm.hpp>
@@ -52,6 +53,17 @@ std::optional<glm::vec3> COMCache::getCOM(long frame)
     });
 
     return std::nullopt;
+}
+
+void COMCache::prefetchAsync(long cur, long ahead, long total_frames)
+{
+    if (total_frames <= 0) {
+        return;
+    }
+    const long last = std::min(cur + ahead, total_frames - 1);
+    for (long f = cur + 1; f <= last; ++f) {
+        getCOM(f); // side-effect: enqueues compute on miss; no-op on hit/pending
+    }
 }
 
 void COMCache::clear()

--- a/src/COMCache.hpp
+++ b/src/COMCache.hpp
@@ -54,6 +54,14 @@ class COMCache
     /// a compute task is pending. Callers should poll on subsequent frames.
     std::optional<glm::vec3> getCOM(long frame);
 
+    /// Enqueues background COM computation for frames [cur+1, min(cur+ahead, total_frames-1)].
+    /// Frames already cached or pending are silently skipped.
+    /// Guards:
+    ///   - If total_frames <= 0: returns immediately (no-op).
+    ///   - If cur+1 > total_frames-1: no frames to prefetch (no-op).
+    /// Caller (main loop) should pass ahead=64 (hard-coded default).
+    void prefetchAsync(long cur, long ahead, long total_frames);
+
     /// Clears the cache and the pending set.
     /// Callers must ensure no compute tasks are in-flight when this is called
     /// (e.g. flush the executor before calling clear() on folder reload).

--- a/src/COMCache.hpp
+++ b/src/COMCache.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <mutex>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <glm/glm.hpp>
+
+// glad must be included before MassParams.hpp, which transitively pulls in
+// settingsIO.hpp → particle.hpp (inline GL methods).  COMCache itself makes
+// no GL calls.
+#include <glad/glad.h> // NOLINT(llvm-include-order)
+
+#include "IExecutor.hpp"
+#include "MassParams.hpp"
+
+// Forward declaration to avoid including the heavyweight settingsIO.hpp header.
+class SettingsIO;
+
+/// COMCache: on-demand, async memoisation of per-frame centre-of-mass values.
+///
+/// Each call to getCOM() either:
+///   - Returns a cached glm::vec3 immediately (cache hit), or
+///   - Returns std::nullopt and enqueues a background compute task (cache miss).
+///
+/// The compute task calls SettingsIO::readPosBuffer() + COMCalculator on the
+/// executor thread. Results are stored under mutex when the task completes.
+///
+/// Thread-safety notes:
+///   - getCOM() and clear() are individually thread-safe.
+///   - Callers must ensure no tasks are in-flight when calling clear()
+///     (e.g. on folder reload, drain the executor before calling clear()).
+///
+/// No GL calls are made anywhere in this class.
+///
+/// Non-copyable, non-movable.
+class COMCache
+{
+  public:
+    /// @param sio       Simulation I/O source; must outlive this object.
+    /// @param mp        Mass parameters used for COM computation.
+    /// @param executor  Task runner (ThreadedExecutor in production,
+    ///                  SynchronousExecutor in tests); must outlive this object.
+    COMCache(SettingsIO& sio, MassParams mp, IExecutor& executor);
+
+    ~COMCache() = default;
+    COMCache(const COMCache&) = delete;
+    COMCache& operator=(const COMCache&) = delete;
+    COMCache(COMCache&&) = delete;
+    COMCache& operator=(COMCache&&) = delete;
+
+    /// Returns the cached COM for @p frame if available, or std::nullopt while
+    /// a compute task is pending. Callers should poll on subsequent frames.
+    std::optional<glm::vec3> getCOM(long frame);
+
+    /// Clears the cache and the pending set.
+    /// Callers must ensure no compute tasks are in-flight when this is called
+    /// (e.g. flush the executor before calling clear() on folder reload).
+    void clear();
+
+  private:
+    SettingsIO& sio_;
+    MassParams mp_;
+    IExecutor& executor_;
+
+    std::unordered_map<long, glm::vec3> cache_;
+    std::unordered_set<long> pending_;
+    std::mutex mutex_;
+};

--- a/src/COMCache.hpp
+++ b/src/COMCache.hpp
@@ -67,6 +67,10 @@ class COMCache
     /// (e.g. flush the executor before calling clear() on folder reload).
     void clear();
 
+    /// Returns the number of frames whose COM is currently cached.
+    /// Thread-safe.
+    std::size_t cachedCount() const;
+
   private:
     SettingsIO& sio_;
     MassParams mp_;
@@ -74,5 +78,5 @@ class COMCache
 
     std::unordered_map<long, glm::vec3> cache_;
     std::unordered_set<long> pending_;
-    std::mutex mutex_;
+    mutable std::mutex mutex_;
 };

--- a/src/COMCache.hpp
+++ b/src/COMCache.hpp
@@ -78,5 +78,6 @@ class COMCache
 
     std::unordered_map<long, glm::vec3> cache_;
     std::unordered_set<long> pending_;
+    std::unordered_set<long> failed_; ///< Frames where readPosBuffer returned empty; prevents re-enqueue.
     mutable std::mutex mutex_;
 };

--- a/src/COMCalculator.hpp
+++ b/src/COMCalculator.hpp
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <span>
+
+#include <glm/glm.hpp>
+
+#include "MassParams.hpp"
+#include "constants.hpp"
+
+/// Pure static utility for computing a mass-weighted centre of mass (COM)
+/// from a span of particle positions.
+///
+/// Particle type is encoded in the w-component of each glm::vec4:
+///   0 → Fe particle, body 1
+///   1 → Si particle, body 1
+///   2 → Fe particle, body 2
+///   3 → Si particle, body 2
+///   any other value → ignored
+///
+/// The result is expressed in display-space coordinates
+/// (i.e. already multiplied by kSimToDisplayScale).
+class COMCalculator
+{
+  public:
+    /// Compute the mass-weighted COM of @p positions using @p mp mass fractions.
+    ///
+    /// @param positions  Span of (x, y, z, type) particle data.
+    /// @param mp         Mass parameters (fractions, earth mass).
+    /// @return           COM in display space, or (0,0,0) if total mass is zero.
+    static glm::vec3 computeMassWeightedCOM(std::span<const glm::vec4> positions, const MassParams& mp)
+    {
+        // ── Step 1: count particles by type ───────────────────────────────────
+        std::size_t nFe1 = 0;
+        std::size_t nSi1 = 0;
+        std::size_t nFe2 = 0;
+        std::size_t nSi2 = 0;
+
+        for (const auto& p : positions) {
+            switch (static_cast<int>(p.w)) {
+                case 0:
+                    ++nFe1;
+                    break;
+                case 1:
+                    ++nSi1;
+                    break;
+                case 2:
+                    ++nFe2;
+                    break;
+                case 3:
+                    ++nSi2;
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        // ── Step 2: per-particle masses (guard: 0 when no particles of that type) ──
+        const double mFe1 = (nFe1 > 0) ? (mp.fraction_fe_body1 * mp.fraction_earth_mass_of_body1 * mp.mass_of_earth) /
+                                             static_cast<double>(nFe1)
+                                       : 0.0;
+        const double mSi1 = (nSi1 > 0) ? (mp.fraction_si_body1 * mp.fraction_earth_mass_of_body1 * mp.mass_of_earth) /
+                                             static_cast<double>(nSi1)
+                                       : 0.0;
+        const double mFe2 = (nFe2 > 0) ? (mp.fraction_fe_body2 * mp.fraction_earth_mass_of_body2 * mp.mass_of_earth) /
+                                             static_cast<double>(nFe2)
+                                       : 0.0;
+        const double mSi2 = (nSi2 > 0) ? (mp.fraction_si_body2 * mp.fraction_earth_mass_of_body2 * mp.mass_of_earth) /
+                                             static_cast<double>(nSi2)
+                                       : 0.0;
+
+        // ── Step 3: accumulate weighted positions in double precision ─────────
+        double sumMx = 0.0;
+        double sumMy = 0.0;
+        double sumMz = 0.0;
+        double totalMass = 0.0;
+
+        for (const auto& p : positions) {
+            double mass = 0.0;
+            switch (static_cast<int>(p.w)) {
+                case 0:
+                    mass = mFe1;
+                    break;
+                case 1:
+                    mass = mSi1;
+                    break;
+                case 2:
+                    mass = mFe2;
+                    break;
+                case 3:
+                    mass = mSi2;
+                    break;
+                default:
+                    continue; // unknown type: skip
+            }
+
+            sumMx += mass * static_cast<double>(p.x);
+            sumMy += mass * static_cast<double>(p.y);
+            sumMz += mass * static_cast<double>(p.z);
+            totalMass += mass;
+        }
+
+        // ── Step 4: guard zero total mass ─────────────────────────────────────
+        if (totalMass == 0.0) {
+            return glm::vec3(0.0f);
+        }
+
+        // ── Step 5: divide and scale to display space ─────────────────────────
+        const auto comX = static_cast<float>(sumMx / totalMass) * kSimToDisplayScale;
+        const auto comY = static_cast<float>(sumMy / totalMass) * kSimToDisplayScale;
+        const auto comZ = static_cast<float>(sumMz / totalMass) * kSimToDisplayScale;
+
+        return glm::vec3(comX, comY, comZ);
+    }
+};

--- a/src/COMFileProvider.hpp
+++ b/src/COMFileProvider.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+// glad must be included before settingsIO.hpp, which transitively includes
+// particle.hpp that uses inline GL methods.
+#include <glad/glad.h> // NOLINT(llvm-include-order)
+
+#include "ICOMProvider.hpp"
+#include "settingsIO.hpp"
+
+/// COMFileProvider: reads per-frame center-of-mass values from a pre-computed
+/// COMFile on disk via SettingsIO.
+///
+/// getCOM() delegates to SettingsIO::checkCOM() and SettingsIO::getCOM().
+/// The scale factor (kSimToDisplayScale) is applied inside SettingsIO::getCOM()
+/// — this class must NOT apply it again.
+///
+/// Non-copyable (stores a reference to SettingsIO).
+class COMFileProvider : public ICOMProvider
+{
+  public:
+    /// @param sio  SettingsIO instance whose comName points at the COMFile.
+    explicit COMFileProvider(SettingsIO& sio) : sio_(sio)
+    {
+    }
+
+    COMFileProvider(const COMFileProvider&) = delete;
+    COMFileProvider& operator=(const COMFileProvider&) = delete;
+
+    /// Returns true and writes the scaled COM into @p out if the COMFile is
+    /// present and the record for @p frame is valid.
+    /// Returns false (leaving @p out unchanged) if checkCOM() reports no file.
+    bool getCOM(long frame, glm::vec3& out) override
+    {
+        if (!sio_.checkCOM()) {
+            return false;
+        }
+        sio_.getCOM(frame, out);
+        return true;
+    }
+
+  private:
+    SettingsIO& sio_;
+};

--- a/src/COMFileProvider.hpp
+++ b/src/COMFileProvider.hpp
@@ -10,7 +10,8 @@
 /// COMFileProvider: reads per-frame center-of-mass values from a pre-computed
 /// COMFile on disk via SettingsIO.
 ///
-/// getCOM() delegates to SettingsIO::checkCOM() and SettingsIO::getCOM().
+/// getCOM() delegates to SettingsIO::getCOM(), which opens the file directly
+/// and returns false for missing files, truncated reads, or frame-index mismatches.
 /// The scale factor (kSimToDisplayScale) is applied inside SettingsIO::getCOM()
 /// — this class must NOT apply it again.
 ///
@@ -28,14 +29,10 @@ class COMFileProvider : public ICOMProvider
 
     /// Returns true and writes the scaled COM into @p out if the COMFile is
     /// present and the record for @p frame is valid.
-    /// Returns false (leaving @p out unchanged) if checkCOM() reports no file.
+    /// Returns false (leaving @p out unchanged) otherwise.
     bool getCOM(long frame, glm::vec3& out) override
     {
-        if (!sio_.checkCOM()) {
-            return false;
-        }
-        sio_.getCOM(frame, out);
-        return true;
+        return sio_.getCOM(frame, out);
     }
 
   private:

--- a/src/FrameCache.cpp
+++ b/src/FrameCache.cpp
@@ -61,6 +61,14 @@ void FrameCache::prefetch(long current, long window, long total_frames)
     for (long f = current + 1; f <= last; ++f) {
         std::unique_lock<std::mutex> lock(mutex_);
 
+        // Cap pending_ at window size to prevent unbounded growth across
+        // repeated prefetch calls when tasks haven't completed yet.
+        // window is the natural ceiling: we never look ahead more than
+        // window frames, so additional outstanding loads have no value.
+        if (pending_.size() >= static_cast<std::size_t>(window)) {
+            break;
+        }
+
         // Skip if already cached or already pending
         if (cache_map_.count(f) > 0 || pending_.count(f) > 0) {
             continue;

--- a/src/FrameCache.cpp
+++ b/src/FrameCache.cpp
@@ -1,0 +1,128 @@
+/*
+ * FrameCache.cpp
+ *
+ * Implementation of the LRU sliding-window frame cache.
+ */
+
+// FrameCache.hpp includes <glad/glad.h> before settingsIO.hpp → particle.hpp,
+// so no special ordering is needed here.
+#include "FrameCache.hpp"
+
+#include <algorithm>
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Constructor
+// ──────────────────────────────────────────────────────────────────────────────
+
+FrameCache::FrameCache(SettingsIO& sio, std::size_t max_frame_bytes, IExecutor& executor)
+    : sio_(sio), max_frames_(0), executor_(executor)
+{
+    const std::size_t frame_size_bytes = (sio_.N > 0) ? static_cast<std::size_t>(sio_.N) * sizeof(glm::vec4) : 0;
+
+    if (frame_size_bytes > 0) {
+        max_frames_ = max_frame_bytes / frame_size_bytes;
+    }
+    // If frame_size_bytes == 0: max_frames_ stays 0 → getFrame always returns nullptr
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// getFrame
+// ──────────────────────────────────────────────────────────────────────────────
+
+std::shared_ptr<std::vector<glm::vec4>> FrameCache::getFrame(long frame)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto it = cache_map_.find(frame);
+    if (it == cache_map_.end()) {
+        return nullptr; // cache miss
+    }
+
+    // Move hit entry to front of LRU list (most-recently-used)
+    lru_list_.erase(it->second.second);
+    lru_list_.push_front(frame);
+    it->second.second = lru_list_.begin();
+
+    return it->second.first;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// prefetch
+// ──────────────────────────────────────────────────────────────────────────────
+
+void FrameCache::prefetch(long current, long window, long total_frames)
+{
+    if (total_frames <= 0) {
+        return;
+    }
+
+    const long last = std::min(current + window, total_frames - 1);
+
+    for (long f = current + 1; f <= last; ++f) {
+        std::unique_lock<std::mutex> lock(mutex_);
+
+        // Skip if already cached or already pending
+        if (cache_map_.count(f) > 0 || pending_.count(f) > 0) {
+            continue;
+        }
+
+        pending_.insert(f);
+        lock.unlock();
+
+        executor_.enqueue([this, f]() {
+            auto data = sio_.readPosBuffer(f);
+            if (data.empty()) {
+                // I/O failed: remove from pending, nothing to insert
+                std::lock_guard<std::mutex> guard(mutex_);
+                pending_.erase(f);
+                return;
+            }
+
+            auto shared = std::make_shared<std::vector<glm::vec4>>(std::move(data));
+
+            std::lock_guard<std::mutex> guard(mutex_);
+            pending_.erase(f);
+            insertLocked(f, std::move(shared));
+        });
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// clear
+// ──────────────────────────────────────────────────────────────────────────────
+
+void FrameCache::clear()
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    cache_map_.clear();
+    lru_list_.clear();
+    pending_.clear();
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// insertLocked (private) — must be called with mutex_ held
+// ──────────────────────────────────────────────────────────────────────────────
+
+void FrameCache::insertLocked(long frame, std::shared_ptr<std::vector<glm::vec4>> data)
+{
+    // Zero-capacity: budget rounds to zero frames; discard all inserts.
+    if (max_frames_ == 0) {
+        return;
+    }
+
+    // If frame is already in cache (race: two tasks for same frame), drop duplicate
+    if (cache_map_.count(frame) > 0) {
+        return;
+    }
+
+    // Insert at front of LRU list (most-recently-used)
+    lru_list_.push_front(frame);
+    cache_map_.emplace(frame, std::make_pair(std::move(data), lru_list_.begin()));
+
+    // Enforce capacity: evict from back (least-recently-used)
+    while (max_frames_ > 0 && lru_list_.size() > max_frames_) {
+        const long lru = lru_list_.back();
+        lru_list_.pop_back();
+        cache_map_.erase(lru);
+    }
+}

--- a/src/FrameCache.cpp
+++ b/src/FrameCache.cpp
@@ -99,6 +99,12 @@ void FrameCache::clear()
     pending_.clear();
 }
 
+std::size_t FrameCache::cachedCount() const
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    return cache_map_.size();
+}
+
 // ──────────────────────────────────────────────────────────────────────────────
 // insertLocked (private) — must be called with mutex_ held
 // ──────────────────────────────────────────────────────────────────────────────

--- a/src/FrameCache.cpp
+++ b/src/FrameCache.cpp
@@ -15,14 +15,14 @@
 // ──────────────────────────────────────────────────────────────────────────────
 
 FrameCache::FrameCache(SettingsIO& sio, std::size_t max_frame_bytes, IExecutor& executor)
-    : sio_(sio), max_frames_(0), executor_(executor)
+    : sio_(sio), max_frames_(0), frame_size_bytes_(0), executor_(executor)
 {
-    const std::size_t frame_size_bytes = (sio_.N > 0) ? static_cast<std::size_t>(sio_.N) * sizeof(glm::vec4) : 0;
+    frame_size_bytes_ = (sio_.N > 0) ? static_cast<std::size_t>(sio_.N) * sizeof(glm::vec4) : 0;
 
-    if (frame_size_bytes > 0) {
-        max_frames_ = max_frame_bytes / frame_size_bytes;
+    if (frame_size_bytes_ > 0) {
+        max_frames_ = max_frame_bytes / frame_size_bytes_;
     }
-    // If frame_size_bytes == 0: max_frames_ stays 0 → getFrame always returns nullptr
+    // If frame_size_bytes_ == 0: max_frames_ stays 0 → getFrame always returns nullptr
 }
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/src/FrameCache.hpp
+++ b/src/FrameCache.hpp
@@ -57,6 +57,10 @@ class FrameCache : public IFrameCache
     /// Clears cache, LRU list, and pending set.
     void clear() override;
 
+    /// Returns the number of frames currently held in the cache.
+    /// Thread-safe.
+    std::size_t cachedCount() const;
+
   private:
     /// Inserts a frame into the cache and enforces LRU capacity.
     /// Must be called with mutex_ held.
@@ -70,5 +74,5 @@ class FrameCache : public IFrameCache
     std::unordered_map<long, std::pair<std::shared_ptr<std::vector<glm::vec4>>, std::list<long>::iterator>> cache_map_;
     std::list<long> lru_list_;
     std::unordered_set<long> pending_;
-    std::mutex mutex_;
+    mutable std::mutex mutex_;
 };

--- a/src/FrameCache.hpp
+++ b/src/FrameCache.hpp
@@ -1,0 +1,74 @@
+/*
+ * FrameCache.hpp
+ *
+ * LRU sliding-window prefetch cache for particle frame data.
+ *
+ * Memory is bounded by max_frame_bytes: at most floor(max_frame_bytes /
+ * frame_size_bytes) frames are kept in memory at once.  When the cache is
+ * full the least-recently-used entry is evicted before the new one is
+ * inserted.
+ *
+ * Background I/O is injected through IExecutor so tests can substitute a
+ * synchronous implementation.  No OpenGL calls are made here; the caller is
+ * responsible for calling particle.stageTranslations() + particle.pushVBO()
+ * after receiving a cache hit.
+ */
+
+#pragma once
+#include <list>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <glm/glm.hpp>
+
+// glad must be included before settingsIO.hpp, which transitively includes
+// particle.hpp (GL types).  FrameCache itself makes no GL calls.
+#include <glad/glad.h> // NOLINT(llvm-include-order)
+
+#include "IExecutor.hpp"
+#include "IFrameCache.hpp"
+#include "settingsIO.hpp"
+
+/// LRU frame cache backed by an injected IExecutor for background I/O.
+class FrameCache : public IFrameCache
+{
+  public:
+    /// @param sio            Source of particle position data (readPosBuffer).
+    /// @param max_frame_bytes Maximum total bytes allowed for cached frames.
+    /// @param executor        Executes background prefetch tasks.
+    FrameCache(SettingsIO& sio, std::size_t max_frame_bytes, IExecutor& executor);
+
+    ~FrameCache() override = default;
+    FrameCache(const FrameCache&) = delete;
+    FrameCache& operator=(const FrameCache&) = delete;
+    FrameCache(FrameCache&&) = delete;
+    FrameCache& operator=(FrameCache&&) = delete;
+
+    /// Returns cached frame, or nullptr on miss. Moves hit entry to MRU.
+    std::shared_ptr<std::vector<glm::vec4>> getFrame(long frame) override;
+
+    /// Enqueues I/O for frames [current+1, min(current+window, total_frames-1)].
+    void prefetch(long current, long window, long total_frames) override;
+
+    /// Clears cache, LRU list, and pending set.
+    void clear() override;
+
+  private:
+    /// Inserts a frame into the cache and enforces LRU capacity.
+    /// Must be called with mutex_ held.
+    void insertLocked(long frame, std::shared_ptr<std::vector<glm::vec4>> data);
+
+    SettingsIO& sio_;
+    std::size_t max_frames_; ///< floor(max_frame_bytes / frame_size_bytes), 0 if uncalculable
+    IExecutor& executor_;
+
+    /// Value: {data, iterator into lru_list_}
+    std::unordered_map<long, std::pair<std::shared_ptr<std::vector<glm::vec4>>, std::list<long>::iterator>> cache_map_;
+    std::list<long> lru_list_;
+    std::unordered_set<long> pending_;
+    std::mutex mutex_;
+};

--- a/src/FrameCache.hpp
+++ b/src/FrameCache.hpp
@@ -62,7 +62,10 @@ class FrameCache : public IFrameCache
     std::size_t cachedCount() const;
 
     /// Returns the per-frame memory footprint (N × sizeof(glm::vec4)).
-    std::size_t frameSizeBytes() const override { return frame_size_bytes_; }
+    std::size_t frameSizeBytes() const override
+    {
+        return frame_size_bytes_;
+    }
 
   private:
     /// Inserts a frame into the cache and enforces LRU capacity.
@@ -70,7 +73,7 @@ class FrameCache : public IFrameCache
     void insertLocked(long frame, std::shared_ptr<std::vector<glm::vec4>> data);
 
     SettingsIO& sio_;
-    std::size_t max_frames_; ///< floor(max_frame_bytes / frame_size_bytes), 0 if uncalculable
+    std::size_t max_frames_;       ///< floor(max_frame_bytes / frame_size_bytes), 0 if uncalculable
     std::size_t frame_size_bytes_; ///< bytes per frame; 0 if N is 0
     IExecutor& executor_;
 

--- a/src/FrameCache.hpp
+++ b/src/FrameCache.hpp
@@ -61,6 +61,9 @@ class FrameCache : public IFrameCache
     /// Thread-safe.
     std::size_t cachedCount() const;
 
+    /// Returns the per-frame memory footprint (N × sizeof(glm::vec4)).
+    std::size_t frameSizeBytes() const override { return frame_size_bytes_; }
+
   private:
     /// Inserts a frame into the cache and enforces LRU capacity.
     /// Must be called with mutex_ held.
@@ -68,6 +71,7 @@ class FrameCache : public IFrameCache
 
     SettingsIO& sio_;
     std::size_t max_frames_; ///< floor(max_frame_bytes / frame_size_bytes), 0 if uncalculable
+    std::size_t frame_size_bytes_; ///< bytes per frame; 0 if N is 0
     IExecutor& executor_;
 
     /// Value: {data, iterator into lru_list_}

--- a/src/ICOMProvider.hpp
+++ b/src/ICOMProvider.hpp
@@ -12,6 +12,9 @@ class ICOMProvider
 {
   public:
     virtual ~ICOMProvider() = default;
+    ICOMProvider() = default;
+    ICOMProvider(const ICOMProvider&) = delete;
+    ICOMProvider& operator=(const ICOMProvider&) = delete;
 
     /// Writes the COM for @p frame into @p out.
     /// @return true if COM is available, false if unavailable (file absent, not yet computed, etc.)

--- a/src/ICOMProvider.hpp
+++ b/src/ICOMProvider.hpp
@@ -1,0 +1,19 @@
+#pragma once
+#include <glm/glm.hpp>
+
+/// ICOMProvider: supplies per-frame center-of-mass positions.
+///
+/// Implementations:
+///   - COMFileProvider  (reads from a pre-computed COMFile on disk)
+///   - COMCacheProvider (computes from particle positions via COMCache) [future]
+///
+/// Caller contract: getCOM() may be called from the main thread only.
+class ICOMProvider
+{
+  public:
+    virtual ~ICOMProvider() = default;
+
+    /// Writes the COM for @p frame into @p out.
+    /// @return true if COM is available, false if unavailable (file absent, not yet computed, etc.)
+    virtual bool getCOM(long frame, glm::vec3& out) = 0;
+};

--- a/src/IExecutor.hpp
+++ b/src/IExecutor.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include <functional>
+
+/// IExecutor: abstract task runner interface.
+/// Production code uses ThreadedExecutor; tests use SynchronousExecutor.
+class IExecutor
+{
+  public:
+    IExecutor() = default;
+    virtual ~IExecutor() = default;
+    IExecutor(const IExecutor&) = delete;
+    IExecutor& operator=(const IExecutor&) = delete;
+
+    virtual void enqueue(std::function<void()> task) = 0;
+};

--- a/src/IFrameCache.hpp
+++ b/src/IFrameCache.hpp
@@ -1,0 +1,39 @@
+/*
+ * IFrameCache.hpp
+ *
+ * Interface for an LRU sliding-window frame cache.
+ * Decouples the main render loop from the concrete implementation.
+ *
+ * Thread safety: implementations must be thread-safe for prefetch() calls
+ * from a background executor, but getFrame() and clear() are called from
+ * the main thread only.
+ */
+
+#pragma once
+#include <memory>
+#include <vector>
+
+#include <glm/glm.hpp>
+
+/// Interface for LRU frame cache. Decouples main loop from implementation.
+class IFrameCache
+{
+  public:
+    virtual ~IFrameCache() = default;
+    IFrameCache(const IFrameCache&) = delete;
+    IFrameCache& operator=(const IFrameCache&) = delete;
+
+    /// Returns cached frame data, or nullptr on cache miss.
+    /// Does NOT enqueue I/O — only prefetch() does background work.
+    virtual std::shared_ptr<std::vector<glm::vec4>> getFrame(long frame) = 0;
+
+    /// Enqueues background I/O for frames [current+1, min(current+window, total_frames-1)].
+    /// Frames already cached or already pending are skipped.
+    virtual void prefetch(long current, long window, long total_frames) = 0;
+
+    /// Clears all cached entries and pending-set. Call before folder reload.
+    virtual void clear() = 0;
+
+  protected:
+    IFrameCache() = default;
+};

--- a/src/IFrameCache.hpp
+++ b/src/IFrameCache.hpp
@@ -34,6 +34,9 @@ class IFrameCache
     /// Clears all cached entries and pending-set. Call before folder reload.
     virtual void clear() = 0;
 
+    /// Returns the size in bytes of one cached frame (N particles × sizeof glm::vec4).
+    virtual std::size_t frameSizeBytes() const = 0;
+
   protected:
     IFrameCache() = default;
 };

--- a/src/MassParams.hpp
+++ b/src/MassParams.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "settingsIO.hpp"
+
+/// Plain aggregate holding per-simulation mass parameters needed for
+/// computing a mass-weighted centre of mass. Values are read from the
+/// RunSetup file via SettingsIO.
+struct MassParams
+{
+    double fraction_earth_mass_of_body1;
+    double fraction_earth_mass_of_body2;
+    double fraction_fe_body1;
+    double fraction_si_body1;
+    double fraction_fe_body2;
+    double fraction_si_body2;
+    double mass_of_earth;
+
+    /// Factory: populate from an already-loaded SettingsIO instance.
+    static MassParams fromSettingsIO(const SettingsIO& sio)
+    {
+        return {sio.getFractionEarthMassOfBody1(),
+                sio.getFractionEarthMassOfBody2(),
+                sio.getFractionFeBody1(),
+                sio.getFractionSiBody1(),
+                sio.getFractionFeBody2(),
+                sio.getFractionSiBody2(),
+                sio.getMassOfEarth()};
+    }
+};

--- a/src/ThreadedExecutor.hpp
+++ b/src/ThreadedExecutor.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <thread>
+
+#include "IExecutor.hpp"
+
+/// ThreadedExecutor: runs enqueued tasks on a single background worker thread.
+///
+/// Ownership model:
+///   - The background thread is started in the constructor and joined in the
+///     destructor (RAII). Destruction is safe even if the queue is non-empty:
+///     all queued tasks complete before the join returns.
+///   - Non-copyable, non-movable.
+class ThreadedExecutor : public IExecutor
+{
+  public:
+    ThreadedExecutor() : stop_(false), worker_([this]() { run(); })
+    {
+    }
+
+    ~ThreadedExecutor() override
+    {
+        {
+            std::lock_guard<std::mutex> lock{mutex_};
+            stop_ = true;
+        }
+        cv_.notify_all();
+        worker_.join();
+    }
+
+    ThreadedExecutor(const ThreadedExecutor&) = delete;
+    ThreadedExecutor& operator=(const ThreadedExecutor&) = delete;
+    ThreadedExecutor(ThreadedExecutor&&) = delete;
+    ThreadedExecutor& operator=(ThreadedExecutor&&) = delete;
+
+    /// Enqueues @p task for execution on the background worker thread.
+    void enqueue(std::function<void()> task) override
+    {
+        {
+            std::lock_guard<std::mutex> lock{mutex_};
+            queue_.push(std::move(task));
+        }
+        cv_.notify_one();
+    }
+
+  private:
+    void run()
+    {
+        while (true) {
+            std::function<void()> task;
+            {
+                std::unique_lock<std::mutex> lock{mutex_};
+                cv_.wait(lock, [this] { return stop_ || !queue_.empty(); });
+                if (stop_ && queue_.empty()) {
+                    break;
+                }
+                task = std::move(queue_.front());
+                queue_.pop();
+            }
+            task();
+        }
+    }
+
+    bool stop_;
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    std::queue<std::function<void()>> queue_;
+    std::thread worker_;
+};

--- a/src/camera.hpp
+++ b/src/camera.hpp
@@ -413,6 +413,14 @@ class Camera
     }
 
     /*
+     * Returns true when the center-of-mass lock is active (camera orbits the COM).
+     */
+    bool isComLocked() const
+    {
+        return comLock;
+    }
+
+    /*
      * Returns true when the rotation sphere is being rendered.
      */
     bool isRenderingSphere() const

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+// Simulation-to-display coordinate scale factor.
+// Applied by the vertex shader (sphereVertex.vs: uniform float transScale)
+// and by getCOM() when converting raw simulation coordinates to display-space coordinates.
+constexpr float kSimToDisplayScale = 0.25f;

--- a/src/particle.hpp
+++ b/src/particle.hpp
@@ -58,6 +58,23 @@ class Particle
     Particle& operator=(const Particle&) = delete;
 
     /*
+     * Stages position data for the next GPU upload without making any GL calls.
+     * May be called from a background thread provided the caller guarantees that
+     * stageTranslations() has returned before pushVBO() is called on the main
+     * thread. Concurrent access to translations or n is not safe.
+     *
+     * If data is nullptr or N <= 0, this method is a silent no-op.
+     */
+    void stageTranslations(const glm::vec4* data, long N)
+    {
+        if (data == nullptr || N <= 0) {
+            return;
+        }
+        translations.assign(data, data + N);
+        n = N;
+    }
+
+    /*
      * Changes the translations in the particle structure.
      * Copies data from the provided array.
      */

--- a/src/settingsIO.hpp
+++ b/src/settingsIO.hpp
@@ -10,6 +10,7 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <vector>
 
 #include "constants.hpp"
 #include "glm/glm.hpp"
@@ -284,6 +285,36 @@ class SettingsIO
         } else if (errorCount == 5) {
             std::cout << "Too many errors. stopping log here" << std::endl;
         }
+    }
+
+    /*
+     * Reads positions from the PosAndVel binary file at a specific frame.
+     * GL-free: safe to call from background threads.
+     * Does not mutate isPlaying, errorCount, or any shared state.
+     * Returns an empty vector on error.
+     */
+    std::vector<glm::vec4> readPosBuffer(long frame)
+    {
+        // clamp frame silently — do NOT mutate isPlaying
+        if (frame < 0)
+            frame = 0;
+        if (frame >= frames)
+            frame = frames - 1;
+        if (N <= 0 || frames <= 0)
+            return {};
+
+        FILE* f = fopen(posName.c_str(), "rb"); // "rb" — binary mode
+        if (!f)
+            return {};
+
+        fseek(f, frame * static_cast<long>(sizeof(glm::vec4)) * 2 * N, SEEK_SET);
+        std::vector<glm::vec4> positions(N);
+        size_t read = fread(positions.data(), sizeof(glm::vec4), static_cast<size_t>(N), f);
+        fclose(f);
+
+        if (static_cast<long>(read) != N)
+            return {};
+        return positions;
     }
 
     /*

--- a/src/settingsIO.hpp
+++ b/src/settingsIO.hpp
@@ -565,7 +565,10 @@ class SettingsIO
         if (!COMFile) {
             return false;
         }
-        fseek(COMFile, frame * sizeof(glm::vec4), SEEK_CUR);
+        if (fseek(COMFile, frame * static_cast<long>(sizeof(glm::vec4)), SEEK_SET) != 0) {
+            fclose(COMFile);
+            return false;
+        }
         glm::vec4 read_val;
         size_t items_read = fread(&read_val, sizeof(glm::vec4), 1, COMFile);
         fclose(COMFile);

--- a/src/settingsIO.hpp
+++ b/src/settingsIO.hpp
@@ -40,6 +40,13 @@ class SettingsIO
         frames = 0;
         isPlaying = false;
         errorCount = 0;
+        FractionEarthMassOfBody1 = 0.0;
+        FractionEarthMassOfBody2 = 0.0;
+        FractionFeBody1 = 0.0;
+        FractionSiBody1 = 0.0;
+        FractionFeBody2 = 0.0;
+        FractionSiBody2 = 0.0;
+        MassOfEarth = 0.0;
     }
 
     /*

--- a/src/settingsIO.hpp
+++ b/src/settingsIO.hpp
@@ -551,24 +551,31 @@ class SettingsIO
     }
 
     /*
-     * Grabs the center of mass from the COMFile.
+     * Reads the center-of-mass record for the given frame from the COMFile.
+     * Returns true and writes the scaled {x,y,z} into value on success.
+     * Returns false (leaving value unchanged) when:
+     *   - the file cannot be opened (missing or permission denied)
+     *   - the read is truncated (fewer than one full vec4 record available)
+     *   - the record's w field does not match the requested frame index
+     * The scale factor kSimToDisplayScale is applied to x, y, z before writing.
      */
-    void getCOM(long frame, glm::vec3& value)
+    bool getCOM(long frame, glm::vec3& value)
     {
-        if (checkCOM()) {
-            FILE* COMFile = fopen(comName.c_str(), "rb");
-            if (COMFile) {
-                fseek(COMFile, frame * sizeof(glm::vec4), SEEK_CUR);
-                glm::vec4 read_val;
-                size_t items_read = fread(&read_val, sizeof(glm::vec4), 1, COMFile);
-                fclose(COMFile);
-                if (items_read == 1 && (long)read_val.w == frame) {
-                    value.x = read_val.x * kSimToDisplayScale;
-                    value.y = read_val.y * kSimToDisplayScale;
-                    value.z = read_val.z * kSimToDisplayScale;
-                }
-            }
+        FILE* COMFile = fopen(comName.c_str(), "rb");
+        if (!COMFile) {
+            return false;
         }
+        fseek(COMFile, frame * sizeof(glm::vec4), SEEK_CUR);
+        glm::vec4 read_val;
+        size_t items_read = fread(&read_val, sizeof(glm::vec4), 1, COMFile);
+        fclose(COMFile);
+        if (items_read == 1 && (long)read_val.w == frame) {
+            value.x = read_val.x * kSimToDisplayScale;
+            value.y = read_val.y * kSimToDisplayScale;
+            value.z = read_val.z * kSimToDisplayScale;
+            return true;
+        }
+        return false;
     }
 
   private:

--- a/src/settingsIO.hpp
+++ b/src/settingsIO.hpp
@@ -318,27 +318,27 @@ class SettingsIO
     {
         return InitialSpin2;
     }
-    double getFractionEarthMassOfBody1()
+    double getFractionEarthMassOfBody1() const
     {
         return FractionEarthMassOfBody1;
     }
-    double getFractionEarthMassOfBody2()
+    double getFractionEarthMassOfBody2() const
     {
         return FractionEarthMassOfBody2;
     }
-    double getFractionFeBody1()
+    double getFractionFeBody1() const
     {
         return FractionFeBody1;
     }
-    double getFractionSiBody1()
+    double getFractionSiBody1() const
     {
         return FractionSiBody1;
     }
-    double getFractionFeBody2()
+    double getFractionFeBody2() const
     {
         return FractionFeBody2;
     }
-    double getFractionSiBody2()
+    double getFractionSiBody2() const
     {
         return FractionSiBody2;
     }
@@ -442,7 +442,7 @@ class SettingsIO
     {
         return UniversalGravity;
     }
-    double getMassOfEarth()
+    double getMassOfEarth() const
     {
         return MassOfEarth;
     }

--- a/src/settingsIO.hpp
+++ b/src/settingsIO.hpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <sstream>
 
+#include "constants.hpp"
 #include "glm/glm.hpp"
 #include "particle.hpp"
 #include "tinyFileDialogs/tinyfiledialogs.h"
@@ -524,9 +525,9 @@ class SettingsIO
                 size_t items_read = fread(&read_val, sizeof(glm::vec4), 1, COMFile);
                 fclose(COMFile);
                 if (items_read == 1 && (long)read_val.w == frame) {
-                    value.x = read_val.x * .25;
-                    value.y = read_val.y * .25;
-                    value.z = read_val.z * .25;
+                    value.x = read_val.x * kSimToDisplayScale;
+                    value.y = read_val.y * kSimToDisplayScale;
+                    value.z = read_val.z * kSimToDisplayScale;
                 }
             }
         }

--- a/src/shaders/sphereVertex.vs
+++ b/src/shaders/sphereVertex.vs
@@ -7,7 +7,7 @@ uniform mat4 view;
 uniform vec3 lightDirection = vec3(0.1, 0.1, 0.85);
 uniform float radius = 100.0f;
 uniform float scale = 5.0;
-uniform float transScale = 0.25;
+uniform float transScale = 0.25; // matches kSimToDisplayScale in src/constants.hpp
 uniform float viewportHeight = 720.0;
 const float REFERENCE_HEIGHT = 720.0;
 

--- a/src/ui/imgui_menu.cpp
+++ b/src/ui/imgui_menu.cpp
@@ -151,6 +151,16 @@ MenuActions renderMainMenu(MenuState& state)
             ImGui::MenuItem("Show Menu", "F1", &state.visible);
             ImGui::EndMenu();
         }
+        if (ImGui::BeginMenu("COM / Cache")) {
+            bool auto_com = state.auto_com_compute;
+            if (ImGui::Checkbox("Auto COM compute", &auto_com)) {
+                actions.toggle_auto_com = true;
+            }
+            ImGui::Separator();
+            ImGui::Text("Frames cached: %d", state.cache_status.frames_cached);
+            ImGui::Text("Memory: %.1f MB", static_cast<float>(state.cache_status.bytes_used) / (1024.0f * 1024.0f));
+            ImGui::EndMenu();
+        }
         ImGui::EndMainMenuBar();
     }
 

--- a/src/ui/imgui_menu.hpp
+++ b/src/ui/imgui_menu.hpp
@@ -11,6 +11,17 @@
 #ifndef PARTICLE_VIEWER_IMGUI_MENU_H
 #define PARTICLE_VIEWER_IMGUI_MENU_H
 
+#include <cstddef>
+
+/*
+ * Live status of the frame and COM caches, populated by ViewerApp each frame.
+ */
+struct CacheStatus
+{
+    int frames_cached = 0;
+    std::size_t bytes_used = 0;
+};
+
 /*
  * Actions triggered by menu interactions, communicated back to ViewerApp.
  */
@@ -22,6 +33,7 @@ struct MenuActions
     bool toggle_fullscreen = false;
     int target_width = 0;
     int target_height = 0;
+    bool toggle_auto_com = false; // toggled by the COM/Cache submenu checkbox
 };
 
 /*
@@ -31,6 +43,8 @@ struct MenuState
 {
     bool visible = true;
     bool debug_mode = false;
+    bool auto_com_compute = false; // reflects the current auto-COM toggle state
+    CacheStatus cache_status;      // populated by ViewerApp each frame
 };
 
 /*

--- a/src/viewerConfig.hpp
+++ b/src/viewerConfig.hpp
@@ -1,0 +1,85 @@
+/*
+ * viewerConfig.hpp
+ *
+ * Save and load viewer configuration (per-simulation settings).
+ * Config file is stored in the simulation folder as viewer.cfg.
+ * Uses a simple INI-style key=value format.
+ */
+
+#ifndef PARTICLE_VIEWER_VIEWER_CONFIG_H
+#define PARTICLE_VIEWER_VIEWER_CONFIG_H
+
+#include <fstream>
+#include <string>
+
+/*
+ * Load viewer.cfg from the given folder path.
+ * Returns true if file exists and auto_com_compute was found.
+ * Returns false (uses defaults) if file doesn't exist or is invalid.
+ * Unknown keys are silently ignored.
+ */
+inline bool loadViewerConfig(const std::string& folder, bool& auto_com_compute)
+{
+    std::string filepath = folder + "/viewer.cfg";
+    std::ifstream file(filepath);
+    if (!file.is_open()) {
+        return false; // File doesn't exist, use defaults
+    }
+
+    std::string line;
+    bool found_auto_com_compute = false;
+
+    while (std::getline(file, line)) {
+        // Skip empty lines and comments
+        if (line.empty() || line[0] == '#' || line[0] == ';') {
+            continue;
+        }
+
+        // Parse key=value
+        size_t eq_pos = line.find('=');
+        if (eq_pos == std::string::npos) {
+            continue;
+        }
+
+        std::string key = line.substr(0, eq_pos);
+        std::string value = line.substr(eq_pos + 1);
+
+        // Trim whitespace
+        key.erase(0, key.find_first_not_of(" \t"));
+        key.erase(key.find_last_not_of(" \t") + 1);
+        value.erase(0, value.find_first_not_of(" \t"));
+        value.erase(value.find_last_not_of(" \t") + 1);
+
+        if (key == "auto_com_compute") {
+            auto_com_compute = (value == "1" || value == "true" || value == "True");
+            found_auto_com_compute = true;
+        }
+        // Unknown keys are silently ignored
+    }
+
+    file.close();
+    return found_auto_com_compute;
+}
+
+/*
+ * Save viewer.cfg to the given folder path.
+ * Returns true on success.
+ * Returns false silently if folder is not writable (no stderr output).
+ */
+inline bool saveViewerConfig(const std::string& folder, bool auto_com_compute)
+{
+    std::string filepath = folder + "/viewer.cfg";
+    std::ofstream file(filepath);
+    if (!file.is_open()) {
+        return false; // Silently return false — simulation folders may be read-only
+    }
+
+    file << "# Particle-Viewer Simulation Configuration\n";
+    file << "# Auto-generated - modify with care\n\n";
+    file << "auto_com_compute=" << (auto_com_compute ? "1" : "0") << "\n";
+
+    file.close();
+    return true;
+}
+
+#endif // PARTICLE_VIEWER_VIEWER_CONFIG_H

--- a/src/viewer_app.cpp
+++ b/src/viewer_app.cpp
@@ -320,6 +320,15 @@ void ViewerApp::run()
         }
         // Update menu state for cache status display
         menu_state_.auto_com_compute = auto_com_compute_;
+        const std::size_t cached_frames = frame_cache_->cachedCount();
+        menu_state_.cache_status.frames_cached = static_cast<int>(cached_frames);
+        menu_state_.cache_status.bytes_used = cached_frames * static_cast<std::size_t>(set_->N) * sizeof(glm::vec4);
+
+        if (menu_state_.debug_mode) {
+            fprintf(stderr, "[Cache] frame=%ld frames_cached=%zu com_cached=%zu auto_com=%d locked=%d\n", cur_frame_,
+                    cached_frames, com_cache_->cachedCount(), static_cast<int>(auto_com_compute_),
+                    static_cast<int>(cam_->isComLocked()));
+        }
         if (set_->isPlaying) {
             cur_frame_++;
         }
@@ -440,12 +449,20 @@ void ViewerApp::drawScene()
         com_ = new_com;
     }
     // Fallback: computed COM from cache if enabled and no COMFile hit
+    bool com_from_cache = false;
     if (!com_set && auto_com_compute_ && cam_->isComLocked()) {
         auto maybe = com_cache_->getCOM(cur_frame_);
         if (maybe.has_value()) {
             com_ = *maybe;
+            com_from_cache = true;
         }
         // On miss: keep previous com_ — camera does not snap
+    }
+    if (menu_state_.debug_mode) {
+        fprintf(stderr, "[COM] frame=%ld file_hit=%d cache_hit=%d com=(%.3f,%.3f,%.3f) auto=%d locked=%d\n", cur_frame_,
+                static_cast<int>(com_set), static_cast<int>(com_from_cache), static_cast<double>(com_.x),
+                static_cast<double>(com_.y), static_cast<double>(com_.z), static_cast<int>(auto_com_compute_),
+                static_cast<int>(cam_->isComLocked()));
     }
     cam_->setSphereCenter(com_);
     render_.sphere_shader.Use();

--- a/src/viewer_app.cpp
+++ b/src/viewer_app.cpp
@@ -52,7 +52,8 @@ static const std::array<QuadVertex, 6> QUAD_VERTICES = {{{-1.0f, 1.0f, 0.0f, 1.0
 ViewerApp::ViewerApp(IOpenGLContext* context)
     : context_(context), imgui_initialized_(false), delta_time_(0.0f), last_frame_(0.0f), cam_(nullptr), part_(nullptr),
       set_(nullptr), view_(), com_(), cur_frame_(0), pixels_(nullptr), com_executor_(nullptr), frame_executor_(nullptr),
-      com_cache_(nullptr), frame_cache_(nullptr), com_file_provider_(nullptr), auto_com_compute_(false)
+      com_cache_(nullptr), frame_cache_(nullptr), com_file_provider_(nullptr), auto_com_compute_(false),
+      com_file_present_(false)
 {
     for (int i = 0; i < 1024; i++) {
         keys_[i] = false;
@@ -302,6 +303,11 @@ void ViewerApp::run()
                 if (!folder.empty()) {
                     saveViewerConfig(folder, auto_com_compute_);
                 }
+                if (auto_com_compute_) {
+                    createCOMInfrastructure();
+                } else {
+                    teardownCOMInfrastructure();
+                }
             }
             if (actions.quit) {
                 context_->setShouldClose(true);
@@ -329,7 +335,7 @@ void ViewerApp::run()
         }
         // COM prefetch — only when COM lock is active, auto-compute is enabled,
         // and no COMFile is present (COMFile takes precedence over auto-compute).
-        if (cam_->isComLocked() && auto_com_compute_ && com_cache_ && !set_->checkCOM()) {
+        if (cam_->isComLocked() && auto_com_compute_ && com_cache_ && !com_file_present_) {
             com_cache_->prefetchAsync(cur_frame_, PREFETCH_LOOKAHEAD_FRAMES, set_->frames);
         }
         if (menu_state_.debug_mode) {
@@ -970,28 +976,44 @@ std::string ViewerApp::extractFolder(const std::string& posName)
     return (slash != std::string::npos) ? posName.substr(0, slash) : "";
 }
 
-void ViewerApp::rebuildCacheInfrastructure()
+void ViewerApp::createCOMInfrastructure()
 {
     MassParams mp = MassParams::fromSettingsIO(*set_);
     com_executor_ = new ThreadedExecutor();
-    frame_executor_ = new ThreadedExecutor();
     com_cache_ = new COMCache(*set_, mp, *com_executor_);
+}
+
+void ViewerApp::teardownCOMInfrastructure()
+{
+    // Drain the executor first: its worker thread holds lambdas that reference
+    // COMCache internals. Joining (via delete) before deleting the cache is safe.
+    delete com_executor_;
+    com_executor_ = nullptr;
+    delete com_cache_;
+    com_cache_ = nullptr;
+}
+
+void ViewerApp::rebuildCacheInfrastructure()
+{
+    frame_executor_ = new ThreadedExecutor();
     frame_cache_ = new FrameCache(*set_, FRAME_CACHE_CAPACITY_BYTES, *frame_executor_);
     com_file_provider_ = new COMFileProvider(*set_);
+    com_file_present_ = set_->checkCOM();
+    if (auto_com_compute_) {
+        createCOMInfrastructure();
+    }
 }
 
 void ViewerApp::teardownCacheInfrastructure()
 {
-    // Drain executors FIRST: their worker threads may hold lambdas that
-    // reference cache internals. Joining before deleting the caches is safe.
-    delete com_executor_;
-    com_executor_ = nullptr;
+    // Drain COM executor before deleting the COM cache.
+    teardownCOMInfrastructure();
+    // Drain frame executor before deleting the frame cache.
     delete frame_executor_;
     frame_executor_ = nullptr;
-    delete com_cache_;
-    com_cache_ = nullptr;
     delete frame_cache_;
     frame_cache_ = nullptr;
     delete com_file_provider_;
     com_file_provider_ = nullptr;
+    com_file_present_ = false;
 }

--- a/src/viewer_app.cpp
+++ b/src/viewer_app.cpp
@@ -543,17 +543,21 @@ void ViewerApp::handleLoadFile()
         teardownCacheInfrastructure();
         delete set_;
         set_ = new_set;
-
-        // Rebuild cache infrastructure with new SettingsIO
-        rebuildCacheInfrastructure();
         com_ = glm::vec3(0.0f);
 
-        // Load per-simulation viewer.cfg for the new folder
+        // Reset before loadViewerConfig so the flag does not leak from the
+        // previous simulation when the new folder has no viewer.cfg.
+        auto_com_compute_ = false;
         std::string folder = extractFolder(set_->posName);
         if (!folder.empty()) {
             loadViewerConfig(folder, auto_com_compute_);
             menu_state_.auto_com_compute = auto_com_compute_;
         }
+
+        // Rebuild AFTER loadViewerConfig so any config that affects
+        // construction (future use) is already applied — consistent with
+        // the constructor ordering fixed in the companion commit.
+        rebuildCacheInfrastructure();
     }
     cur_frame_ = 0;
 }

--- a/src/viewer_app.cpp
+++ b/src/viewer_app.cpp
@@ -8,6 +8,7 @@
 #include "viewer_app.hpp"
 
 #include <array>
+#include <cassert>
 #include <cstdlib>
 #include <iostream>
 #include <string>
@@ -269,8 +270,7 @@ void ViewerApp::run()
         menu_state_.auto_com_compute = auto_com_compute_;
         const std::size_t cached_frames = frame_cache_ ? frame_cache_->cachedCount() : 0;
         menu_state_.cache_status.frames_cached = static_cast<int>(cached_frames);
-        menu_state_.cache_status.bytes_used =
-            frame_cache_ ? cached_frames * frame_cache_->frameSizeBytes() : 0;
+        menu_state_.cache_status.bytes_used = frame_cache_ ? cached_frames * frame_cache_->frameSizeBytes() : 0;
 
         if (imgui_initialized_) {
             if (menu_state_.debug_mode) {
@@ -978,9 +978,17 @@ std::string ViewerApp::extractFolder(const std::string& posName)
 
 void ViewerApp::createCOMInfrastructure()
 {
+    assert(com_executor_ == nullptr && com_cache_ == nullptr &&
+           "createCOMInfrastructure called with live COM objects; call teardownCOMInfrastructure first");
     MassParams mp = MassParams::fromSettingsIO(*set_);
     com_executor_ = new ThreadedExecutor();
-    com_cache_ = new COMCache(*set_, mp, *com_executor_);
+    try {
+        com_cache_ = new COMCache(*set_, mp, *com_executor_);
+    } catch (...) {
+        delete com_executor_;
+        com_executor_ = nullptr;
+        throw;
+    }
 }
 
 void ViewerApp::teardownCOMInfrastructure()

--- a/src/viewer_app.cpp
+++ b/src/viewer_app.cpp
@@ -263,6 +263,14 @@ void ViewerApp::run()
         cam_->RenderSphere();
         drawFBO();
 
+        // Update menu state with current cache status — must happen before
+        // renderMainMenu so the UI reflects values from the current frame.
+        menu_state_.auto_com_compute = auto_com_compute_;
+        const std::size_t cached_frames = frame_cache_ ? frame_cache_->cachedCount() : 0;
+        menu_state_.cache_status.frames_cached = static_cast<int>(cached_frames);
+        menu_state_.cache_status.bytes_used =
+            frame_cache_ ? cached_frames * frame_cache_->frameSizeBytes() : 0;
+
         if (imgui_initialized_) {
             if (menu_state_.debug_mode) {
                 float fps = (delta_time_ > 0.0f) ? 1.0f / delta_time_ : 0.0f;
@@ -305,29 +313,29 @@ void ViewerApp::run()
 
         context_->swapBuffers();
 
-        if (set_->frames > 1 && frame_cache_) {
-            auto frame_data = frame_cache_->getFrame(cur_frame_);
-            if (frame_data) {
-                part_->stageTranslations(frame_data->data(), static_cast<long>(frame_data->size()));
-            } else {
+        if (set_->frames > 1) {
+            bool loaded = false;
+            if (frame_cache_) {
+                auto frame_data = frame_cache_->getFrame(cur_frame_);
+                if (frame_data) {
+                    part_->stageTranslations(frame_data->data(), static_cast<long>(frame_data->size()));
+                    loaded = true;
+                }
+                frame_cache_->prefetch(cur_frame_, PREFETCH_LOOKAHEAD_FRAMES, set_->frames);
+            }
+            if (!loaded) {
                 set_->readPosVelFile(cur_frame_, part_, false);
             }
-            frame_cache_->prefetch(cur_frame_, PREFETCH_LOOKAHEAD_FRAMES, set_->frames);
         }
         // COM prefetch — only when COM lock is active, auto-compute is enabled,
         // and no COMFile is present (COMFile takes precedence over auto-compute).
         if (cam_->isComLocked() && auto_com_compute_ && com_cache_ && !set_->checkCOM()) {
             com_cache_->prefetchAsync(cur_frame_, PREFETCH_LOOKAHEAD_FRAMES, set_->frames);
         }
-        // Update menu state for cache status display
-        menu_state_.auto_com_compute = auto_com_compute_;
-        const std::size_t cached_frames = frame_cache_ ? frame_cache_->cachedCount() : 0;
-        menu_state_.cache_status.frames_cached = static_cast<int>(cached_frames);
-        menu_state_.cache_status.bytes_used = cached_frames * static_cast<std::size_t>(set_->N) * sizeof(glm::vec4);
-
         if (menu_state_.debug_mode) {
+            const std::size_t cached_frames_now = frame_cache_ ? frame_cache_->cachedCount() : 0;
             fprintf(stderr, "[Cache] frame=%ld frames_cached=%zu com_cached=%zu auto_com=%d locked=%d\n", cur_frame_,
-                    cached_frames, com_cache_ ? com_cache_->cachedCount() : 0, static_cast<int>(auto_com_compute_),
+                    cached_frames_now, com_cache_ ? com_cache_->cachedCount() : 0, static_cast<int>(auto_com_compute_),
                     static_cast<int>(cam_->isComLocked()));
         }
         if (set_->isPlaying) {

--- a/src/viewer_app.cpp
+++ b/src/viewer_app.cpp
@@ -16,6 +16,7 @@
 #include <SDL3/SDL.h>          // NOLINT(llvm-include-order)
 // clang-format on
 
+#include "MassParams.hpp"
 #include "debugOverlay.hpp"
 #include "imgui.h"
 #include "imgui_impl_opengl3.h"
@@ -50,12 +51,20 @@ static const std::array<QuadVertex, 6> QUAD_VERTICES = {{{-1.0f, 1.0f, 0.0f, 1.0
 
 ViewerApp::ViewerApp(IOpenGLContext* context)
     : context_(context), imgui_initialized_(false), delta_time_(0.0f), last_frame_(0.0f), cam_(nullptr), part_(nullptr),
-      set_(nullptr), view_(), com_(), cur_frame_(0), pixels_(nullptr)
+      set_(nullptr), view_(), com_(), cur_frame_(0), pixels_(nullptr), com_executor_(nullptr), frame_executor_(nullptr),
+      com_cache_(nullptr), frame_cache_(nullptr), com_file_provider_(nullptr), auto_com_compute_(false)
 {
     for (int i = 0; i < 1024; i++) {
         keys_[i] = false;
     }
     set_ = new SettingsIO();
+    rebuildCacheInfrastructure();
+
+    std::string folder = extractFolder(set_->posName);
+    if (!folder.empty()) {
+        loadViewerConfig(folder, auto_com_compute_);
+        menu_state_.auto_com_compute = auto_com_compute_;
+    }
 }
 
 ViewerApp::~ViewerApp()
@@ -278,6 +287,14 @@ void ViewerApp::run()
             if (actions.toggle_fullscreen) {
                 toggleFullscreen();
             }
+            if (actions.toggle_auto_com) {
+                auto_com_compute_ = !auto_com_compute_;
+                menu_state_.auto_com_compute = auto_com_compute_;
+                std::string folder = extractFolder(set_->posName);
+                if (!folder.empty()) {
+                    saveViewerConfig(folder, auto_com_compute_);
+                }
+            }
             if (actions.quit) {
                 context_->setShouldClose(true);
             }
@@ -289,8 +306,20 @@ void ViewerApp::run()
         context_->swapBuffers();
 
         if (set_->frames > 1) {
-            set_->readPosVelFile(cur_frame_, part_, false);
+            auto frame_data = frame_cache_->getFrame(cur_frame_);
+            if (frame_data) {
+                part_->stageTranslations(frame_data->data(), static_cast<long>(frame_data->size()));
+            } else {
+                set_->readPosVelFile(cur_frame_, part_, false);
+            }
+            frame_cache_->prefetch(cur_frame_, PREFETCH_LOOKAHEAD_FRAMES, set_->frames);
         }
+        // COM prefetch — only when COM lock is active and auto-compute is enabled
+        if (cam_->isComLocked() && auto_com_compute_) {
+            com_cache_->prefetchAsync(cur_frame_, PREFETCH_LOOKAHEAD_FRAMES, set_->frames);
+        }
+        // Update menu state for cache status display
+        menu_state_.auto_com_compute = auto_com_compute_;
         if (set_->isPlaying) {
             cur_frame_++;
         }
@@ -404,7 +433,20 @@ void ViewerApp::beforeDraw()
 
 void ViewerApp::drawScene()
 {
-    set_->getCOM(cur_frame_, com_);
+    // Try COMFile first (no regression when COMFile is present)
+    glm::vec3 new_com{};
+    bool com_set = com_file_provider_->getCOM(cur_frame_, new_com);
+    if (com_set) {
+        com_ = new_com;
+    }
+    // Fallback: computed COM from cache if enabled and no COMFile hit
+    if (!com_set && auto_com_compute_ && cam_->isComLocked()) {
+        auto maybe = com_cache_->getCOM(cur_frame_);
+        if (maybe.has_value()) {
+            com_ = *maybe;
+        }
+        // On miss: keep previous com_ — camera does not snap
+    }
     cam_->setSphereCenter(com_);
     render_.sphere_shader.Use();
     part_->pushVBO();
@@ -479,8 +521,22 @@ void ViewerApp::handleLoadFile()
 {
     SettingsIO* new_set = set_->loadFile(part_, false);
     if (new_set && new_set != set_) {
+        // Safe teardown order: drain executors FIRST so no tasks reference
+        // the old SettingsIO after it is deleted.
+        teardownCacheInfrastructure();
         delete set_;
         set_ = new_set;
+
+        // Rebuild cache infrastructure with new SettingsIO
+        rebuildCacheInfrastructure();
+        com_ = glm::vec3(0.0f);
+
+        // Load per-simulation viewer.cfg for the new folder
+        std::string folder = extractFolder(set_->posName);
+        if (!folder.empty()) {
+            loadViewerConfig(folder, auto_com_compute_);
+            menu_state_.auto_com_compute = auto_com_compute_;
+        }
     }
     cur_frame_ = 0;
 }
@@ -702,6 +758,10 @@ void ViewerApp::cleanup()
         render_.circle_vao = 0;
     }
 
+    // Cache teardown: drain executors FIRST so no in-flight tasks reference
+    // the caches or SettingsIO after they are deleted.
+    teardownCacheInfrastructure();
+
     delete set_;
     set_ = nullptr;
     delete cam_;
@@ -864,4 +924,44 @@ void ViewerApp::loadWindowSettings()
     } else {
         std::cout << "No window config found, using defaults" << std::endl;
     }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/*
+ * Returns the directory portion of a file path (everything before the last '/').
+ * Returns an empty string when no '/' is found (no parent directory).
+ */
+std::string ViewerApp::extractFolder(const std::string& posName)
+{
+    auto slash = posName.rfind('/');
+    return (slash != std::string::npos) ? posName.substr(0, slash) : "";
+}
+
+void ViewerApp::rebuildCacheInfrastructure()
+{
+    MassParams mp = MassParams::fromSettingsIO(*set_);
+    com_executor_ = new ThreadedExecutor();
+    frame_executor_ = new ThreadedExecutor();
+    com_cache_ = new COMCache(*set_, mp, *com_executor_);
+    frame_cache_ = new FrameCache(*set_, FRAME_CACHE_CAPACITY_BYTES, *frame_executor_);
+    com_file_provider_ = new COMFileProvider(*set_);
+}
+
+void ViewerApp::teardownCacheInfrastructure()
+{
+    // Drain executors FIRST: their worker threads may hold lambdas that
+    // reference cache internals. Joining before deleting the caches is safe.
+    delete com_executor_;
+    com_executor_ = nullptr;
+    delete frame_executor_;
+    frame_executor_ = nullptr;
+    delete com_cache_;
+    com_cache_ = nullptr;
+    delete frame_cache_;
+    frame_cache_ = nullptr;
+    delete com_file_provider_;
+    com_file_provider_ = nullptr;
 }

--- a/src/viewer_app.cpp
+++ b/src/viewer_app.cpp
@@ -314,8 +314,9 @@ void ViewerApp::run()
             }
             frame_cache_->prefetch(cur_frame_, PREFETCH_LOOKAHEAD_FRAMES, set_->frames);
         }
-        // COM prefetch — only when COM lock is active and auto-compute is enabled
-        if (cam_->isComLocked() && auto_com_compute_ && com_cache_) {
+        // COM prefetch — only when COM lock is active, auto-compute is enabled,
+        // and no COMFile is present (COMFile takes precedence over auto-compute).
+        if (cam_->isComLocked() && auto_com_compute_ && com_cache_ && !set_->checkCOM()) {
             com_cache_->prefetchAsync(cur_frame_, PREFETCH_LOOKAHEAD_FRAMES, set_->frames);
         }
         // Update menu state for cache status display

--- a/src/viewer_app.cpp
+++ b/src/viewer_app.cpp
@@ -58,12 +58,12 @@ ViewerApp::ViewerApp(IOpenGLContext* context)
         keys_[i] = false;
     }
     set_ = new SettingsIO();
-    rebuildCacheInfrastructure();
 
     std::string folder = extractFolder(set_->posName);
     if (!folder.empty()) {
         loadViewerConfig(folder, auto_com_compute_);
         menu_state_.auto_com_compute = auto_com_compute_;
+        rebuildCacheInfrastructure();
     }
 }
 
@@ -305,7 +305,7 @@ void ViewerApp::run()
 
         context_->swapBuffers();
 
-        if (set_->frames > 1) {
+        if (set_->frames > 1 && frame_cache_) {
             auto frame_data = frame_cache_->getFrame(cur_frame_);
             if (frame_data) {
                 part_->stageTranslations(frame_data->data(), static_cast<long>(frame_data->size()));
@@ -315,18 +315,18 @@ void ViewerApp::run()
             frame_cache_->prefetch(cur_frame_, PREFETCH_LOOKAHEAD_FRAMES, set_->frames);
         }
         // COM prefetch — only when COM lock is active and auto-compute is enabled
-        if (cam_->isComLocked() && auto_com_compute_) {
+        if (cam_->isComLocked() && auto_com_compute_ && com_cache_) {
             com_cache_->prefetchAsync(cur_frame_, PREFETCH_LOOKAHEAD_FRAMES, set_->frames);
         }
         // Update menu state for cache status display
         menu_state_.auto_com_compute = auto_com_compute_;
-        const std::size_t cached_frames = frame_cache_->cachedCount();
+        const std::size_t cached_frames = frame_cache_ ? frame_cache_->cachedCount() : 0;
         menu_state_.cache_status.frames_cached = static_cast<int>(cached_frames);
         menu_state_.cache_status.bytes_used = cached_frames * static_cast<std::size_t>(set_->N) * sizeof(glm::vec4);
 
         if (menu_state_.debug_mode) {
             fprintf(stderr, "[Cache] frame=%ld frames_cached=%zu com_cached=%zu auto_com=%d locked=%d\n", cur_frame_,
-                    cached_frames, com_cache_->cachedCount(), static_cast<int>(auto_com_compute_),
+                    cached_frames, com_cache_ ? com_cache_->cachedCount() : 0, static_cast<int>(auto_com_compute_),
                     static_cast<int>(cam_->isComLocked()));
         }
         if (set_->isPlaying) {
@@ -444,13 +444,13 @@ void ViewerApp::drawScene()
 {
     // Try COMFile first (no regression when COMFile is present)
     glm::vec3 new_com{};
-    bool com_set = com_file_provider_->getCOM(cur_frame_, new_com);
+    bool com_set = com_file_provider_ && com_file_provider_->getCOM(cur_frame_, new_com);
     if (com_set) {
         com_ = new_com;
     }
     // Fallback: computed COM from cache if enabled and no COMFile hit
     bool com_from_cache = false;
-    if (!com_set && auto_com_compute_ && cam_->isComLocked()) {
+    if (!com_set && auto_com_compute_ && cam_->isComLocked() && com_cache_) {
         auto maybe = com_cache_->getCOM(cur_frame_);
         if (maybe.has_value()) {
             com_ = *maybe;

--- a/src/viewer_app.hpp
+++ b/src/viewer_app.hpp
@@ -204,6 +204,10 @@ class ViewerApp
     // COM auto-compute toggle (persisted in viewer.cfg per simulation folder)
     bool auto_com_compute_;
 
+    // Cached result of checkCOM(). Updated by rebuildCacheInfrastructure(),
+    // cleared by teardownCacheInfrastructure(). Avoids per-frame disk stat.
+    bool com_file_present_;
+
     // ============================================
     // Frame Playback State
     // ============================================
@@ -269,6 +273,8 @@ class ViewerApp
     static std::string extractFolder(const std::string& posName);
     void rebuildCacheInfrastructure();
     void teardownCacheInfrastructure();
+    void createCOMInfrastructure();
+    void teardownCOMInfrastructure();
 
     static constexpr std::size_t FRAME_CACHE_CAPACITY_BYTES = 256ULL * 1024 * 1024;
     static constexpr long PREFETCH_LOOKAHEAD_FRAMES = 64;

--- a/src/viewer_app.hpp
+++ b/src/viewer_app.hpp
@@ -21,6 +21,10 @@
 #include <glad/glad.h>       // NOLINT(llvm-include-order)
 // clang-format on
 
+#include "COMCache.hpp"
+#include "COMFileProvider.hpp"
+#include "FrameCache.hpp"
+#include "ThreadedExecutor.hpp"
 #include "camera.hpp"
 #include "glm/glm.hpp"
 #include "glm/gtc/matrix_transform.hpp"
@@ -31,6 +35,7 @@
 #include "settingsIO.hpp"
 #include "shader.hpp"
 #include "ui/imgui_menu.hpp"
+#include "viewerConfig.hpp"
 
 /*
  * Window configuration.
@@ -188,6 +193,18 @@ class ViewerApp
     glm::vec3 com_;
 
     // ============================================
+    // COM / Frame Cache Infrastructure
+    // ============================================
+    ThreadedExecutor* com_executor_;
+    ThreadedExecutor* frame_executor_;
+    COMCache* com_cache_;
+    FrameCache* frame_cache_;
+    COMFileProvider* com_file_provider_;
+
+    // COM auto-compute toggle (persisted in viewer.cfg per simulation folder)
+    bool auto_com_compute_;
+
+    // ============================================
     // Frame Playback State
     // ============================================
     GLint cur_frame_;
@@ -245,6 +262,16 @@ class ViewerApp
     // ============================================
     void cleanup();
     void shutdownImGui();
+
+    // ============================================
+    // Helpers
+    // ============================================
+    static std::string extractFolder(const std::string& posName);
+    void rebuildCacheInfrastructure();
+    void teardownCacheInfrastructure();
+
+    static constexpr std::size_t FRAME_CACHE_CAPACITY_BYTES = 256ULL * 1024 * 1024;
+    static constexpr long PREFETCH_LOOKAHEAD_FRAMES = 64;
 };
 
 #endif // PARTICLE_VIEWER_VIEWER_APP_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(ParticleViewerTests
     ${TEST_TESTING_FILES}
     ${TEST_VISUAL_REGRESSION_FILES}
     ${TESTING_UTILITY_SOURCES}
+    ${CMAKE_SOURCE_DIR}/src/COMCache.cpp
     ${CMAKE_SOURCE_DIR}/src/Image.cpp
     ${CMAKE_SOURCE_DIR}/src/graphics/SDL3Context.cpp
     stb_image_write_impl.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ target_include_directories(ParticleViewerTests PRIVATE
 # Add glad source for OpenGL function pointers
 target_sources(ParticleViewerTests PRIVATE
     ${CMAKE_SOURCE_DIR}/src/glad/src/glad.c
+    ${CMAKE_SOURCE_DIR}/src/FrameCache.cpp
     ${CMAKE_SOURCE_DIR}/src/ui/imgui_menu.cpp
     ${imgui_SOURCE_DIR}/imgui.cpp
     ${imgui_SOURCE_DIR}/imgui_draw.cpp

--- a/tests/core/COMCacheTests.cpp
+++ b/tests/core/COMCacheTests.cpp
@@ -300,3 +300,24 @@ TEST_F(COMCacheTest, COMCache_EmptyPositions_ReturnsZeroVec)
     ASSERT_TRUE(second.has_value());
     expectNearVec3(*second, glm::vec3(0.f, 0.f, 0.f));
 }
+
+// ─── Test 10: CachedCount ────────────────────────────────────────────────────
+
+TEST_F(COMCacheTest, COMCache_CachedCount_AfterGetCOM_IsOne)
+{
+    // Arrange — 1 Fe1 particle; SynchronousExecutor runs compute inline
+    auto [sio, path] = makeOneFSio({{4.f, 0.f, 0.f, 0.f}});
+    COMCache cache(sio, kSimpleMassParams, executor_);
+
+    // Assert: starts at 0
+    EXPECT_EQ(cache.cachedCount(), std::size_t{0});
+
+    // Act: first getCOM enqueues + runs inline; second call is a cache hit
+    cache.getCOM(0);
+    cache.getCOM(0);
+
+    // Assert: exactly one frame in cache
+    EXPECT_EQ(cache.cachedCount(), std::size_t{1});
+
+    std::remove(path.c_str());
+}

--- a/tests/core/COMCacheTests.cpp
+++ b/tests/core/COMCacheTests.cpp
@@ -52,6 +52,14 @@ class DeferredExecutor : public IExecutor
         tasks_.push_back(std::move(task));
     }
 
+    void runAll()
+    {
+        for (auto& t : tasks_) {
+            t();
+        }
+        tasks_.clear();
+    }
+
     int enqueue_count{0};
 
   private:
@@ -279,29 +287,91 @@ TEST_F(COMCacheTest, COMCache_PrefetchAsync_NoDuplicateEnqueue)
     std::remove(path.c_str());
 }
 
-// ─── Test 9: EmptyPositions ──────────────────────────────────────────────────
+// ─── Test 9: IOFailure ───────────────────────────────────────────────────────
+// When readPosBuffer() returns empty (e.g. N=0 or disk error), getCOM() must:
+//   - Return nullopt on every call (never return a cached (0,0,0))
+//   - Not re-enqueue the compute task after the first failure (failed_ set)
 
-TEST_F(COMCacheTest, COMCache_EmptyPositions_ReturnsZeroVec)
+TEST_F(COMCacheTest, COMCache_IOFailure_ReturnsNulloptOnFirstCall)
 {
-    // Arrange — N=0 so readPosBuffer returns an empty vector;
-    // COMCalculator returns (0,0,0) for an empty span; result is stored.
+    // Arrange — N=0 so readPosBuffer always returns {}
     SettingsIO sio;
     sio.N = 0;
-    sio.frames = 0; // readPosBuffer returns {} when N<=0 || frames<=0
+    sio.frames = 0;
     COMCache cache(sio, kSimpleMassParams, executor_);
 
-    // Act — first call: miss, task runs inline → cache stores (0,0,0)
-    std::optional<glm::vec3> first = cache.getCOM(0);
-    // second call: hit → returns stored (0,0,0)
-    std::optional<glm::vec3> second = cache.getCOM(0);
+    // Act — first call: miss, task runs inline, positions empty → NOT cached
+    std::optional<glm::vec3> result = cache.getCOM(0);
 
-    // Assert
-    EXPECT_FALSE(first.has_value()); // first call always returns nullopt
-    ASSERT_TRUE(second.has_value());
-    expectNearVec3(*second, glm::vec3(0.f, 0.f, 0.f));
+    // Assert — nullopt: I/O failure must not be memoised as (0,0,0)
+    EXPECT_FALSE(result.has_value());
 }
 
-// ─── Test 10: CachedCount ────────────────────────────────────────────────────
+TEST_F(COMCacheTest, COMCache_IOFailure_ReturnsNulloptPersistently)
+{
+    // Arrange — N=0 so readPosBuffer always returns {}
+    SettingsIO sio;
+    sio.N = 0;
+    sio.frames = 0;
+    COMCache cache(sio, kSimpleMassParams, executor_);
+
+    // Act — first call runs inline task (empty → goes to failed_ set)
+    cache.getCOM(0);
+    // second call — frame is in failed_; must return nullopt without re-enqueuing
+    std::optional<glm::vec3> second = cache.getCOM(0);
+
+    // Assert — still nullopt; no COM=(0,0,0) stored
+    EXPECT_FALSE(second.has_value());
+}
+
+TEST_F(COMCacheTest, COMCache_IOFailure_DoesNotReenqueue)
+{
+    // Arrange — DeferredExecutor so we can count enqueue calls
+    SettingsIO sio;
+    sio.N = 0;
+    sio.frames = 0;
+    DeferredExecutor deferred;
+    COMCache cache(sio, kSimpleMassParams, deferred);
+
+    // Act — first call enqueues; run tasks manually so failed_ is populated
+    cache.getCOM(0);
+    deferred.runAll(); // executes the lambda → positions empty → inserts to failed_
+    // second call — frame already failed; must NOT enqueue again
+    cache.getCOM(0);
+
+    // Assert — only 1 enqueue total
+    EXPECT_EQ(deferred.enqueue_count, 1);
+}
+
+// ─── Test 11: ClearResetsFailedSet ──────────────────────────────────────────
+// clear() must clear failed_ so that failed frames can be retried after a
+// folder switch (i.e., after new cache infrastructure is built via clear()).
+
+TEST_F(COMCacheTest, COMCache_Clear_AllowsFailedFrameToBeReenqueued)
+{
+    // Arrange — N=0 so positions are empty; DeferredExecutor to control timing
+    SettingsIO sio;
+    sio.N = 0;
+    sio.frames = 0;
+    DeferredExecutor deferred;
+    COMCache cache(sio, kSimpleMassParams, deferred);
+
+    // Act — first call enqueues; run task so frame enters failed_
+    cache.getCOM(0);
+    deferred.runAll();
+    // Confirm: frame is now in failed_; second call should NOT re-enqueue
+    cache.getCOM(0);
+    const int enqueue_before_clear = deferred.enqueue_count;
+
+    // Act — clear() must also clear failed_
+    cache.clear();
+    cache.getCOM(0);
+    const int enqueue_after_clear = deferred.enqueue_count;
+
+    // Assert
+    EXPECT_EQ(enqueue_before_clear, 1); // failed_ blocked re-enqueue
+    EXPECT_EQ(enqueue_after_clear, 2);  // clear() allowed re-enqueue
+}
 
 TEST_F(COMCacheTest, COMCache_CachedCount_AfterGetCOM_IsOne)
 {

--- a/tests/core/COMCacheTests.cpp
+++ b/tests/core/COMCacheTests.cpp
@@ -199,7 +199,87 @@ TEST_F(COMCacheTest, COMCache_Clear_ErasesCache)
     std::remove(path.c_str());
 }
 
-// ─── Test 6: EmptyPositions ──────────────────────────────────────────────────
+// ─── Helpers (multi-frame) ────────────────────────────────────────────────────
+
+/// Builds a SettingsIO pointing at a file with @p frame_count identical frames,
+/// each containing one particle at (1, 0, 0, 0).
+/// The caller is responsible for removing the returned path after the test.
+static std::pair<SettingsIO, std::string> makeMultiFrameFSio(int frame_count = 5)
+{
+    const long n = 1;
+    TestFrameBuilder builder(n);
+    for (int i = 0; i < frame_count; ++i) {
+        builder.addFrame({{1.f, 0.f, 0.f, 0.f}});
+    }
+    std::string path = builder.writeToTempFile("_comcache_multi.bin");
+
+    SettingsIO sio;
+    sio.posName = path;
+    sio.N = n;
+    sio.frames = static_cast<long>(frame_count);
+    return {sio, path};
+}
+
+// ─── Test 6: PrefetchAsync_PopulatesCache ─────────────────────────────────────
+
+TEST_F(COMCacheTest, COMCache_PrefetchAsync_PopulatesCache)
+{
+    // Arrange — 5 frames (indices 0-4), SynchronousExecutor runs tasks inline.
+    auto [sio, path] = makeMultiFrameFSio(5);
+    COMCache cache(sio, kSimpleMassParams, executor_);
+
+    // Act — prefetch window: cur=0, ahead=3, total=5 → enqueues frames 1, 2, 3
+    cache.prefetchAsync(0, 3, 5);
+
+    // Assert — frames 1, 2, 3 are populated (cache hit)
+    EXPECT_TRUE(cache.getCOM(1).has_value());
+    EXPECT_TRUE(cache.getCOM(2).has_value());
+    EXPECT_TRUE(cache.getCOM(3).has_value());
+    // Frame 4 was not prefetched (outside window) — should still miss
+    EXPECT_FALSE(cache.getCOM(4).has_value());
+
+    std::remove(path.c_str());
+}
+
+// ─── Test 7: PrefetchAsync_ZeroTotalFrames_DoesNothing ───────────────────────
+
+TEST_F(COMCacheTest, COMCache_PrefetchAsync_ZeroTotalFrames_DoesNothing)
+{
+    // Arrange — SettingsIO with no frames; DeferredExecutor to count enqueues.
+    SettingsIO sio;
+    sio.N = 0;
+    sio.frames = 0;
+    DeferredExecutor deferred;
+    COMCache cache(sio, kSimpleMassParams, deferred);
+
+    // Act — must not crash; total_frames=0 is a guard condition
+    cache.prefetchAsync(0, 64, 0);
+
+    // Assert — nothing was enqueued
+    EXPECT_EQ(deferred.enqueue_count, 0);
+}
+
+// ─── Test 8: PrefetchAsync_NoDuplicateEnqueue ────────────────────────────────
+
+TEST_F(COMCacheTest, COMCache_PrefetchAsync_NoDuplicateEnqueue)
+{
+    // Arrange — DeferredExecutor: tasks are stored but NOT executed, so the
+    // pending set still contains frames 1, 2, 3 during the second prefetch call.
+    auto [sio, path] = makeMultiFrameFSio(5);
+    DeferredExecutor deferred;
+    COMCache cache(sio, kSimpleMassParams, deferred);
+
+    // Act — two identical prefetch calls; second must not re-enqueue pending frames
+    cache.prefetchAsync(0, 3, 5); // enqueues frames 1, 2, 3 → count = 3
+    cache.prefetchAsync(0, 3, 5); // all frames already pending → count stays at 3
+
+    // Assert
+    EXPECT_EQ(deferred.enqueue_count, 3);
+
+    std::remove(path.c_str());
+}
+
+// ─── Test 9: EmptyPositions ──────────────────────────────────────────────────
 
 TEST_F(COMCacheTest, COMCache_EmptyPositions_ReturnsZeroVec)
 {

--- a/tests/core/COMCacheTests.cpp
+++ b/tests/core/COMCacheTests.cpp
@@ -1,0 +1,222 @@
+/*
+ * COMCacheTests.cpp
+ *
+ * Unit tests for COMCache — async frame-COM memoization.
+ * Uses SynchronousExecutor so tasks run inline (no threading uncertainty).
+ * Uses TestFrameBuilder to write synthetic binary frame files for SettingsIO.
+ */
+
+#include <cstdio>
+#include <functional>
+#include <optional>
+#include <vector>
+
+// Include glad before other OpenGL-related headers to avoid conflicts
+#include <glad/glad.h>
+#include <gtest/gtest.h>
+
+#include <glm/glm.hpp>
+
+#include "COMCache.hpp"
+#include "COMCalculator.hpp"
+#include "IExecutor.hpp"
+#include "MassParams.hpp"
+#include "MockOpenGL.hpp"
+#include "settingsIO.hpp"
+#include "testing/SynchronousExecutor.hpp"
+#include "testing/TestFrameBuilder.hpp"
+
+// ─── Sentinel MassParams ─────────────────────────────────────────────────────
+
+/// All fractions = 1.0 so that a COM is always computable for any nonzero span.
+constexpr MassParams kSimpleMassParams{
+    1.0, // fraction_earth_mass_of_body1
+    1.0, // fraction_earth_mass_of_body2
+    1.0, // fraction_fe_body1
+    1.0, // fraction_si_body1
+    1.0, // fraction_fe_body2
+    1.0, // fraction_si_body2
+    1.0  // mass_of_earth
+};
+
+// ─── DeferredExecutor ────────────────────────────────────────────────────────
+
+/// Stores enqueued tasks without running them. Lets tests verify that the
+/// pending-set guard prevents double-enqueue before any task executes.
+class DeferredExecutor : public IExecutor
+{
+  public:
+    void enqueue(std::function<void()> task) override
+    {
+        ++enqueue_count;
+        tasks_.push_back(std::move(task));
+    }
+
+    int enqueue_count{0};
+
+  private:
+    std::vector<std::function<void()>> tasks_;
+};
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Checks that two vec3 values are component-wise within tolerance.
+static void expectNearVec3(const glm::vec3& actual, const glm::vec3& expected, double tol = 1e-5)
+{
+    EXPECT_NEAR(static_cast<double>(actual.x), static_cast<double>(expected.x), tol);
+    EXPECT_NEAR(static_cast<double>(actual.y), static_cast<double>(expected.y), tol);
+    EXPECT_NEAR(static_cast<double>(actual.z), static_cast<double>(expected.z), tol);
+}
+
+/// Builds a SettingsIO pointing at a 1-frame binary file containing @p positions.
+/// The caller is responsible for removing the returned path after the test.
+static std::pair<SettingsIO, std::string> makeOneFSio(const std::vector<glm::vec4>& positions)
+{
+    const long n = static_cast<long>(positions.size());
+    TestFrameBuilder builder(n);
+    builder.addFrame(positions);
+    std::string path = builder.writeToTempFile("_comcache.bin");
+
+    SettingsIO sio;
+    sio.posName = path;
+    sio.N = n;
+    sio.frames = 1;
+    return {sio, path};
+}
+
+// ─── Fixture ─────────────────────────────────────────────────────────────────
+
+class COMCacheTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        MockOpenGL::reset();
+        MockOpenGL::initGLAD();
+    }
+
+    SynchronousExecutor executor_;
+};
+
+// ─── Test 1: CacheMiss ───────────────────────────────────────────────────────
+
+TEST_F(COMCacheTest, COMCache_CacheMiss_ReturnsNullopt)
+{
+    // Arrange — 1 Fe1 particle at (4, 0, 0)
+    auto [sio, path] = makeOneFSio({{4.f, 0.f, 0.f, 0.f}});
+    COMCache cache(sio, kSimpleMassParams, executor_);
+
+    // Act — first call: cache is empty; task enqueued (runs inline but returns
+    // nullopt before the map is re-checked)
+    std::optional<glm::vec3> result = cache.getCOM(0);
+
+    // Assert
+    EXPECT_FALSE(result.has_value());
+
+    std::remove(path.c_str());
+}
+
+// ─── Test 2: CacheHit ────────────────────────────────────────────────────────
+
+TEST_F(COMCacheTest, COMCache_CacheHit_ReturnsValue)
+{
+    // Arrange — 1 Fe1 particle; SynchronousExecutor runs the compute task inline
+    // so after the first getCOM the cache is already populated.
+    auto [sio, path] = makeOneFSio({{4.f, 0.f, 0.f, 0.f}});
+    COMCache cache(sio, kSimpleMassParams, executor_);
+    cache.getCOM(0); // first call — miss, but task runs inline → cache filled
+
+    // Act — second call: cache hit
+    std::optional<glm::vec3> result = cache.getCOM(0);
+
+    // Assert
+    EXPECT_TRUE(result.has_value());
+
+    std::remove(path.c_str());
+}
+
+// ─── Test 3: ComputedValue ───────────────────────────────────────────────────
+
+TEST_F(COMCacheTest, COMCache_ComputedValue_MatchesCOMCalculator)
+{
+    // Arrange — 1 Fe1 particle at (4, 0, 0).
+    // Expected COM = (4,0,0) * kSimToDisplayScale = (1,0,0).
+    const glm::vec4 particle{4.f, 0.f, 0.f, 0.f};
+    auto [sio, path] = makeOneFSio({particle});
+    COMCache cache(sio, kSimpleMassParams, executor_);
+
+    // Compute reference value directly via COMCalculator.
+    std::span<const glm::vec4> span{&particle, 1};
+    const glm::vec3 expected = COMCalculator::computeMassWeightedCOM(span, kSimpleMassParams);
+
+    cache.getCOM(0);                                   // populate cache
+    std::optional<glm::vec3> result = cache.getCOM(0); // hit
+
+    // Assert
+    ASSERT_TRUE(result.has_value());
+    expectNearVec3(*result, expected);
+
+    std::remove(path.c_str());
+}
+
+// ─── Test 4: NoPendingDuplicate ──────────────────────────────────────────────
+
+TEST_F(COMCacheTest, COMCache_NoPendingDuplicate_DoesNotDoubleEnqueue)
+{
+    // Arrange — DeferredExecutor: tasks are stored but NOT executed, so the
+    // pending set still contains frame 0 during the second getCOM call.
+    auto [sio, path] = makeOneFSio({{1.f, 0.f, 0.f, 0.f}});
+    DeferredExecutor deferred;
+    COMCache cache(sio, kSimpleMassParams, deferred);
+
+    // Act — first call enqueues; second call finds frame in pending and skips.
+    cache.getCOM(0);
+    cache.getCOM(0);
+
+    // Assert — executor was called exactly once
+    EXPECT_EQ(deferred.enqueue_count, 1);
+
+    std::remove(path.c_str());
+}
+
+// ─── Test 5: Clear ───────────────────────────────────────────────────────────
+
+TEST_F(COMCacheTest, COMCache_Clear_ErasesCache)
+{
+    // Arrange — populate cache via SynchronousExecutor
+    auto [sio, path] = makeOneFSio({{2.f, 0.f, 0.f, 0.f}});
+    COMCache cache(sio, kSimpleMassParams, executor_);
+    cache.getCOM(0);                          // miss → task runs inline → cache filled
+    ASSERT_TRUE(cache.getCOM(0).has_value()); // sanity: hit before clear
+
+    // Act
+    cache.clear();
+
+    // Assert — after clear, getCOM returns nullopt (cache miss)
+    std::optional<glm::vec3> result = cache.getCOM(0);
+    EXPECT_FALSE(result.has_value());
+
+    std::remove(path.c_str());
+}
+
+// ─── Test 6: EmptyPositions ──────────────────────────────────────────────────
+
+TEST_F(COMCacheTest, COMCache_EmptyPositions_ReturnsZeroVec)
+{
+    // Arrange — N=0 so readPosBuffer returns an empty vector;
+    // COMCalculator returns (0,0,0) for an empty span; result is stored.
+    SettingsIO sio;
+    sio.N = 0;
+    sio.frames = 0; // readPosBuffer returns {} when N<=0 || frames<=0
+    COMCache cache(sio, kSimpleMassParams, executor_);
+
+    // Act — first call: miss, task runs inline → cache stores (0,0,0)
+    std::optional<glm::vec3> first = cache.getCOM(0);
+    // second call: hit → returns stored (0,0,0)
+    std::optional<glm::vec3> second = cache.getCOM(0);
+
+    // Assert
+    EXPECT_FALSE(first.has_value()); // first call always returns nullopt
+    ASSERT_TRUE(second.has_value());
+    expectNearVec3(*second, glm::vec3(0.f, 0.f, 0.f));
+}

--- a/tests/core/COMCalculatorTests.cpp
+++ b/tests/core/COMCalculatorTests.cpp
@@ -1,0 +1,220 @@
+#include <span>
+
+// Include glad before other OpenGL-related headers to avoid conflicts
+#include <glad/glad.h>
+#include <gtest/gtest.h>
+
+#include <glm/glm.hpp>
+
+#include "COMCalculator.hpp"
+#include "MassParams.hpp"
+#include "constants.hpp"
+
+/// Sentinel MassParams for tests where exact mass values don't matter,
+/// only that all fractions are nonzero so a COM is computable.
+constexpr MassParams kSimpleMassParams{
+    1.0, // fraction_earth_mass_of_body1
+    1.0, // fraction_earth_mass_of_body2
+    1.0, // fraction_fe_body1
+    1.0, // fraction_si_body1
+    1.0, // fraction_fe_body2
+    1.0, // fraction_si_body2
+    1.0  // mass_of_earth
+};
+
+/// Checks that two vec3 values are component-wise within tolerance.
+static void expectNearVec3(const glm::vec3& actual, const glm::vec3& expected, double tol = 1e-5)
+{
+    EXPECT_NEAR(static_cast<double>(actual.x), static_cast<double>(expected.x), tol);
+    EXPECT_NEAR(static_cast<double>(actual.y), static_cast<double>(expected.y), tol);
+    EXPECT_NEAR(static_cast<double>(actual.z), static_cast<double>(expected.z), tol);
+}
+
+class COMCalculatorTest : public ::testing::Test
+{
+};
+
+// ─── Test 1 ──────────────────────────────────────────────────────────────────
+
+TEST_F(COMCalculatorTest, COMCalculator_EmptySpan_ReturnsZero)
+{
+    // Arrange
+    std::span<const glm::vec4> empty{};
+
+    // Act
+    glm::vec3 result = COMCalculator::computeMassWeightedCOM(empty, kSimpleMassParams);
+
+    // Assert
+    expectNearVec3(result, glm::vec3(0.0f));
+}
+
+// ─── Test 2 ──────────────────────────────────────────────────────────────────
+
+TEST_F(COMCalculatorTest, COMCalculator_SingleFe1Particle_ReturnsPosScaled)
+{
+    // Arrange — one Fe1 particle at sim position (10, 20, 30)
+    // With a single particle the COM equals that position; scale by kSimToDisplayScale.
+    const glm::vec4 particle{10.0f, 20.0f, 30.0f, 0.0f};
+    std::span<const glm::vec4> positions{&particle, 1};
+
+    const glm::vec3 expected = glm::vec3(10.0f, 20.0f, 30.0f) * kSimToDisplayScale;
+
+    // Act
+    glm::vec3 result = COMCalculator::computeMassWeightedCOM(positions, kSimpleMassParams);
+
+    // Assert
+    expectNearVec3(result, expected);
+}
+
+// ─── Test 3 ──────────────────────────────────────────────────────────────────
+
+TEST_F(COMCalculatorTest, COMCalculator_TwoParticlesEqualMass_ReturnsMidpoint)
+{
+    // Arrange — two Fe1 particles; equal per-particle mass → midpoint × scale
+    const glm::vec4 particles[2] = {
+        {0.0f, 0.0f, 0.0f, 0.0f},
+        {10.0f, 20.0f, 30.0f, 0.0f},
+    };
+    std::span<const glm::vec4> positions{particles};
+
+    const glm::vec3 midpointSim{5.0f, 10.0f, 15.0f};
+    const glm::vec3 expected = midpointSim * kSimToDisplayScale;
+
+    // Act
+    glm::vec3 result = COMCalculator::computeMassWeightedCOM(positions, kSimpleMassParams);
+
+    // Assert
+    expectNearVec3(result, expected);
+}
+
+// ─── Test 4 ──────────────────────────────────────────────────────────────────
+
+TEST_F(COMCalculatorTest, COMCalculator_UnknownTypeIgnored_UsesOnlyKnownTypes)
+{
+    // Arrange — one type-0 particle at (10,20,30) and one unknown type (500) at (100,200,300).
+    // Only the type-0 particle should contribute.
+    const glm::vec4 particles[2] = {
+        {10.0f, 20.0f, 30.0f, 0.0f},
+        {100.0f, 200.0f, 300.0f, 500.0f},
+    };
+    std::span<const glm::vec4> positions{particles};
+
+    const glm::vec3 expected = glm::vec3(10.0f, 20.0f, 30.0f) * kSimToDisplayScale;
+
+    // Act
+    glm::vec3 result = COMCalculator::computeMassWeightedCOM(positions, kSimpleMassParams);
+
+    // Assert
+    expectNearVec3(result, expected);
+}
+
+// ─── Test 5 ──────────────────────────────────────────────────────────────────
+
+TEST_F(COMCalculatorTest, COMCalculator_ZeroBodyCount_ReturnsZero)
+{
+    // Arrange — particles are type-2 (Fe body 2) but fraction_fe_body2 = 0.
+    // m_Fe2 = (0.0 * 1.0 * 1.0) / N_Fe2 = 0, so total_mass = 0 → (0,0,0).
+    // (Zero comes from fraction_fe_body2 = 0, not from a missing-particle N=0 guard.)
+    // The N=0 guards fire for Fe1/Si1/Si2 (no such particles in the span).
+    const glm::vec4 particles[2] = {
+        {5.0f, 5.0f, 5.0f, 2.0f},
+        {-5.0f, -5.0f, -5.0f, 2.0f},
+    };
+    std::span<const glm::vec4> positions{particles};
+
+    MassParams mp{
+        1.0, // fraction_earth_mass_of_body1
+        1.0, // fraction_earth_mass_of_body2
+        1.0, // fraction_fe_body1
+        1.0, // fraction_si_body1
+        0.0, // fraction_fe_body2 — zero → m_Fe2 = 0, total_mass = 0
+        0.0, // fraction_si_body2
+        1.0  // mass_of_earth
+    };
+
+    // Act
+    glm::vec3 result = COMCalculator::computeMassWeightedCOM(positions, mp);
+
+    // Assert
+    expectNearVec3(result, glm::vec3(0.0f));
+}
+
+// ─── Test 6 ──────────────────────────────────────────────────────────────────
+
+TEST_F(COMCalculatorTest, COMCalculator_TwoBodyMix_WeightedCorrectly)
+{
+    // Arrange
+    // Body 1: fraction_earth_mass_of_body1=2.0, fraction_fe_body1=1.0, mass_of_earth=1.0
+    //         → m_Fe1 = 1.0 * 2.0 * 1.0 / 1 = 2.0
+    // Body 2: fraction_earth_mass_of_body2=1.0, fraction_fe_body2=1.0
+    //         → m_Fe2 = 1.0 * 1.0 * 1.0 / 1 = 1.0
+    //
+    // Particle type-0 at (0, 0, 0): contributes 2.0 * (0, 0, 0) = (0, 0, 0)
+    // Particle type-2 at (6, 0, 0): contributes 1.0 * (6, 0, 0) = (6, 0, 0)
+    // total_mass = 3.0
+    // COM_sim = (6/3, 0, 0) = (2, 0, 0)
+    // COM_display = (2, 0, 0) * kSimToDisplayScale = (0.5, 0, 0)
+    const glm::vec4 particles[2] = {
+        {0.0f, 0.0f, 0.0f, 0.0f},
+        {6.0f, 0.0f, 0.0f, 2.0f},
+    };
+    std::span<const glm::vec4> positions{particles};
+
+    MassParams mp{
+        2.0, // fraction_earth_mass_of_body1
+        1.0, // fraction_earth_mass_of_body2
+        1.0, // fraction_fe_body1
+        0.0, // fraction_si_body1 (unused)
+        1.0, // fraction_fe_body2
+        0.0, // fraction_si_body2 (unused)
+        1.0  // mass_of_earth
+    };
+
+    const glm::vec3 expected{0.5f, 0.0f, 0.0f};
+
+    // Act
+    glm::vec3 result = COMCalculator::computeMassWeightedCOM(positions, mp);
+
+    // Assert
+    expectNearVec3(result, expected);
+}
+
+// ─── Test 7 ──────────────────────────────────────────────────────────────────
+
+TEST_F(COMCalculatorTest, COMCalculator_SingleSi1Particle_ReturnsPosScaled)
+{
+    // Arrange — one Si1 particle (type 1) at sim position (4, 8, 12).
+    // Verifies the case-1 branch is exercised independently.
+    const glm::vec4 particle{4.0f, 8.0f, 12.0f, 1.0f};
+    std::span<const glm::vec4> positions{&particle, 1};
+
+    const glm::vec3 expected = glm::vec3(4.0f, 8.0f, 12.0f) * kSimToDisplayScale;
+
+    // Act
+    glm::vec3 result = COMCalculator::computeMassWeightedCOM(positions, kSimpleMassParams);
+
+    // Assert
+    expectNearVec3(result, expected);
+}
+
+// ─── Test 8 ──────────────────────────────────────────────────────────────────
+
+TEST_F(COMCalculatorTest, COMCalculator_NegativePositions_WeightedCorrectly)
+{
+    // Arrange — two Fe1 particles with negative coordinates; COM is their midpoint.
+    const glm::vec4 particles[2] = {
+        {-8.0f, -4.0f, -2.0f, 0.0f},
+        {-2.0f, 0.0f, 2.0f, 0.0f},
+    };
+    std::span<const glm::vec4> positions{particles};
+
+    // Equal mass → midpoint × scale
+    const glm::vec3 midpointSim{-5.0f, -2.0f, 0.0f};
+    const glm::vec3 expected = midpointSim * kSimToDisplayScale;
+
+    // Act
+    glm::vec3 result = COMCalculator::computeMassWeightedCOM(positions, kSimpleMassParams);
+
+    // Assert
+    expectNearVec3(result, expected);
+}

--- a/tests/core/COMFileProviderTests.cpp
+++ b/tests/core/COMFileProviderTests.cpp
@@ -1,8 +1,9 @@
 /*
  * COMFileProviderTests.cpp
  *
- * Unit tests for COMFileProvider — wraps SettingsIO::checkCOM() and
- * SettingsIO::getCOM() behind the ICOMProvider interface.
+ * Unit tests for COMFileProvider — wraps SettingsIO::getCOM() behind the
+ * ICOMProvider interface. getCOM() returns false for missing files, truncated
+ * reads, and frame-index mismatches.
  */
 
 #include <cstdio>
@@ -72,6 +73,76 @@ TEST(COMFileProviderTest, COMFileProvider_WithCOMFile_ReturnsTrue)
     EXPECT_FLOAT_EQ(out.x, 1.0f * kSimToDisplayScale);
     EXPECT_FLOAT_EQ(out.y, 2.0f * kSimToDisplayScale);
     EXPECT_FLOAT_EQ(out.z, 3.0f * kSimToDisplayScale);
+
+    std::remove(tmpPath.c_str());
+}
+
+// ─── Test 3: TruncatedFile ───────────────────────────────────────────────────
+// When the COMFile exists but contains no data for the requested frame,
+// getCOM() must return false and leave `out` unchanged.
+
+TEST(COMFileProviderTest, COMFileProvider_TruncatedFile_ReturnsFalse)
+{
+    // Arrange — create an empty COMFile (0 bytes).
+    const std::string tmpPath = ::testing::TempDir() + "com_file_provider_test_truncated.bin";
+    {
+        FILE* f = fopen(tmpPath.c_str(), "wb");
+        ASSERT_NE(f, nullptr) << "Could not create temp file";
+        fclose(f);
+    }
+
+    SettingsIO sio;
+    sio.comName = tmpPath;
+    COMFileProvider provider(sio);
+
+    glm::vec3 out{99.f, 99.f, 99.f};
+
+    // Act
+    bool result = provider.getCOM(0, out);
+
+    // Assert — empty file → no valid record → false; out unchanged.
+    EXPECT_FALSE(result);
+    EXPECT_FLOAT_EQ(out.x, 99.f);
+    EXPECT_FLOAT_EQ(out.y, 99.f);
+    EXPECT_FLOAT_EQ(out.z, 99.f);
+
+    std::remove(tmpPath.c_str());
+}
+
+// ─── Test 4: FrameIndexMismatch ──────────────────────────────────────────────
+// When the record exists but its w field does not match the requested frame,
+// getCOM() must return false and leave `out` unchanged.
+
+TEST(COMFileProviderTest, COMFileProvider_FrameIndexMismatch_ReturnsFalse)
+{
+    // Arrange — write two records so fread succeeds at frame 1's offset,
+    // but r1.w = 99 ≠ 1, exercising the (long)read_val.w == frame guard.
+    const std::string tmpPath = ::testing::TempDir() + "com_file_provider_test_mismatch.bin";
+    {
+        glm::vec4 r0{0.f, 0.f, 0.f, 0.f};  // padding — fseek skips this for frame 1
+        glm::vec4 r1{1.f, 2.f, 3.f, 99.f}; // w=99 ≠ frame=1 → mismatch
+        FILE* f = fopen(tmpPath.c_str(), "wb");
+        ASSERT_NE(f, nullptr) << "Could not create temp file";
+        fwrite(&r0, sizeof(glm::vec4), 1, f);
+        fwrite(&r1, sizeof(glm::vec4), 1, f);
+        fclose(f);
+    }
+
+    SettingsIO sio;
+    sio.comName = tmpPath;
+    COMFileProvider provider(sio);
+
+    glm::vec3 out{99.f, 99.f, 99.f};
+
+    // Act — frame=1: fseek skips r0, fread reads r1 (items_read=1),
+    //       but (long)99.f != 1 → returns false.
+    bool result = provider.getCOM(1, out);
+
+    // Assert — frame index mismatch → false; out unchanged.
+    EXPECT_FALSE(result);
+    EXPECT_FLOAT_EQ(out.x, 99.f);
+    EXPECT_FLOAT_EQ(out.y, 99.f);
+    EXPECT_FLOAT_EQ(out.z, 99.f);
 
     std::remove(tmpPath.c_str());
 }

--- a/tests/core/COMFileProviderTests.cpp
+++ b/tests/core/COMFileProviderTests.cpp
@@ -1,0 +1,77 @@
+/*
+ * COMFileProviderTests.cpp
+ *
+ * Unit tests for COMFileProvider — wraps SettingsIO::checkCOM() and
+ * SettingsIO::getCOM() behind the ICOMProvider interface.
+ */
+
+#include <cstdio>
+
+// glad must be included before any header that transitively pulls in
+// particle.hpp (which uses inline GL methods).
+#include <glad/glad.h>
+#include <gtest/gtest.h>
+
+#include <glm/glm.hpp>
+
+#include "COMFileProvider.hpp"
+#include "constants.hpp"
+#include "settingsIO.hpp"
+
+// ─── Test 1: NoCOMFile ───────────────────────────────────────────────────────
+
+TEST(COMFileProviderTest, COMFileProvider_NoCOMFile_ReturnsFalse)
+{
+    // Arrange — SettingsIO pointing at a path that does not exist on disk.
+    SettingsIO sio;
+    sio.comName = "/tmp/no_such_com_file_that_exists.bin";
+
+    COMFileProvider provider(sio);
+
+    glm::vec3 out{99.f, 99.f, 99.f};
+
+    // Act
+    bool result = provider.getCOM(0, out);
+
+    // Assert — provider reports unavailable; sentinel left unchanged.
+    EXPECT_FALSE(result);
+    EXPECT_FLOAT_EQ(out.x, 99.f);
+    EXPECT_FLOAT_EQ(out.y, 99.f);
+    EXPECT_FLOAT_EQ(out.z, 99.f);
+}
+
+// ─── Test 2: WithCOMFile ─────────────────────────────────────────────────────
+
+TEST(COMFileProviderTest, COMFileProvider_WithCOMFile_ReturnsTrue)
+{
+    // Arrange — write a minimal COMFile: one glm::vec4 for frame 0.
+    // SettingsIO::getCOM() reads: fseek(frame * sizeof(vec4), SEEK_CUR)
+    // then fread(&read_val, sizeof(vec4), 1, ...) and checks (long)read_val.w == frame.
+    // For frame 0: w = 0.0f so (long)0.0f == 0 → valid.
+    const std::string tmpPath = ::testing::TempDir() + "com_file_provider_test_frame0.bin";
+    {
+        glm::vec4 record{1.0f, 2.0f, 3.0f, 0.0f}; // x,y,z payload; w = frame index 0
+        FILE* f = fopen(tmpPath.c_str(), "wb");
+        ASSERT_NE(f, nullptr) << "Could not open temp file for writing";
+        fwrite(&record, sizeof(glm::vec4), 1, f);
+        fclose(f);
+    }
+
+    SettingsIO sio;
+    sio.comName = tmpPath;
+
+    COMFileProvider provider(sio);
+
+    glm::vec3 out{0.f, 0.f, 0.f};
+
+    // Act
+    bool result = provider.getCOM(0, out);
+
+    // Assert — provider returns true; out = {1,2,3} * kSimToDisplayScale.
+    EXPECT_TRUE(result);
+    EXPECT_FLOAT_EQ(out.x, 1.0f * kSimToDisplayScale);
+    EXPECT_FLOAT_EQ(out.y, 2.0f * kSimToDisplayScale);
+    EXPECT_FLOAT_EQ(out.z, 3.0f * kSimToDisplayScale);
+
+    std::remove(tmpPath.c_str());
+}

--- a/tests/core/ConstantsTests.cpp
+++ b/tests/core/ConstantsTests.cpp
@@ -1,0 +1,15 @@
+#include <gtest/gtest.h>
+
+#include "constants.hpp"
+
+TEST(kSimToDisplayScale, HasExpectedValue)
+{
+    // Arrange
+    constexpr float expected = 0.25f;
+
+    // Act
+    constexpr float actual = kSimToDisplayScale;
+
+    // Assert
+    EXPECT_EQ(actual, expected);
+}

--- a/tests/core/FrameCacheTests.cpp
+++ b/tests/core/FrameCacheTests.cpp
@@ -373,3 +373,39 @@ TEST_F(FrameCacheTest, FrameCache_CachedCount_ReflectsInsertedFrames)
 
     std::remove(path.c_str());
 }
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 11. pending_ set is capped at window size across repeated prefetch calls
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(FrameCacheTest, FrameCache_PendingSetCappedAtWindowSize_DoesNotGrowBeyondWindow)
+{
+    // Arrange — use CountingExecutor so tasks are enqueued but never run,
+    // keeping all frames in pending_ indefinitely.
+    constexpr long N = 2;
+    TestFrameBuilder builder(N);
+    for (int i = 0; i < 10; ++i) {
+        builder.addFrame({{static_cast<float>(i), 0.f, 0.f, 0.f}, {static_cast<float>(i), 0.f, 0.f, 1.f}});
+    }
+    std::string path = builder.writeToTempFile("_fc_pending_cap.bin");
+
+    SettingsIO sio;
+    sio.posName = path;
+    sio.N = N;
+    sio.frames = 10;
+    constexpr std::size_t maxBytes = 100 * sizeof(glm::vec4);
+    constexpr long window = 3;
+
+    CountingExecutor counting;
+    FrameCache cache(sio, maxBytes, counting);
+
+    // Act — call prefetch twice with different current frames so new frames
+    // would be enqueued on the second call if the cap is absent.
+    cache.prefetch(0, window, 10); // enqueues frames 1,2,3 → pending_ size = 3
+    cache.prefetch(1, window, 10); // frame 4 is new; without cap, pending_ grows to 4
+
+    // Assert — pending_ must never exceed the window size.
+    EXPECT_EQ(counting.callCount, static_cast<int>(window));
+
+    std::remove(path.c_str());
+}

--- a/tests/core/FrameCacheTests.cpp
+++ b/tests/core/FrameCacheTests.cpp
@@ -340,3 +340,36 @@ TEST_F(FrameCacheTest, FrameCache_ZeroCapacity_NeverCaches)
 
     std::remove(path.c_str());
 }
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 10. cachedCount() reflects the number of frames currently in the cache
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(FrameCacheTest, FrameCache_CachedCount_ReflectsInsertedFrames)
+{
+    // Arrange
+    constexpr long N = 2;
+    TestFrameBuilder builder(N);
+    builder.addFrame({{1.f, 2.f, 3.f, 0.f}, {4.f, 5.f, 6.f, 1.f}});
+    builder.addFrame({{7.f, 8.f, 9.f, 0.f}, {10.f, 11.f, 12.f, 1.f}});
+    builder.addFrame({{13.f, 14.f, 15.f, 0.f}, {16.f, 17.f, 18.f, 1.f}});
+    std::string path = builder.writeToTempFile("_fc_count.bin");
+
+    SettingsIO sio;
+    sio.posName = path;
+    sio.N = N;
+    sio.frames = 3;
+    constexpr std::size_t maxBytes = 10 * sizeof(glm::vec4);
+    FrameCache cache(sio, maxBytes, executor_);
+
+    // Assert: starts empty
+    EXPECT_EQ(cache.cachedCount(), std::size_t{0});
+
+    // Act — SynchronousExecutor runs tasks inline; frames 1 and 2 are inserted
+    cache.prefetch(0, 2, 3);
+
+    // Assert: two frames now in cache
+    EXPECT_EQ(cache.cachedCount(), std::size_t{2});
+
+    std::remove(path.c_str());
+}

--- a/tests/core/FrameCacheTests.cpp
+++ b/tests/core/FrameCacheTests.cpp
@@ -1,0 +1,342 @@
+/*
+ * FrameCacheTests.cpp
+ *
+ * Unit tests for FrameCache — LRU sliding-window prefetch cache.
+ * Uses SynchronousExecutor so all enqueued tasks run inline.
+ * No GL calls are made by FrameCache; MockOpenGL is reset for isolation only.
+ */
+
+#include <cstdio>
+#include <functional>
+#include <memory>
+#include <vector>
+
+// Include glad first to avoid OpenGL header conflicts
+#include <glad/glad.h>
+#include <gtest/gtest.h>
+
+#include <glm/glm.hpp>
+
+#include "FrameCache.hpp"
+#include "IFrameCache.hpp"
+#include "MockOpenGL.hpp"
+#include "settingsIO.hpp"
+#include "testing/SynchronousExecutor.hpp"
+#include "testing/TestFrameBuilder.hpp"
+
+// ──────────────────────────────────────────────────────────────────────────────
+// CountingExecutor: records enqueue calls without running tasks.
+// Used to verify that duplicate enqueues are suppressed.
+// ──────────────────────────────────────────────────────────────────────────────
+
+class CountingExecutor : public IExecutor
+{
+  public:
+    void enqueue(std::function<void()> /*task*/) override
+    {
+        ++callCount;
+    }
+
+    int callCount = 0;
+};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Test fixture
+// ──────────────────────────────────────────────────────────────────────────────
+
+class FrameCacheTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        MockOpenGL::reset();
+        MockOpenGL::initGLAD();
+    }
+
+    SynchronousExecutor executor_;
+};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 1. getFrame on a fresh cache returns nullptr (cache miss)
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(FrameCacheTest, FrameCache_GetFrame_MissReturnNullptr)
+{
+    // Arrange
+    SettingsIO sio;
+    sio.N = 2;
+    sio.frames = 3;
+    constexpr std::size_t maxBytes = 10 * sizeof(glm::vec4);
+    FrameCache cache(sio, maxBytes, executor_);
+
+    // Act
+    auto result = cache.getFrame(0);
+
+    // Assert
+    EXPECT_EQ(result, nullptr);
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 2. prefetch populates cache; getFrame returns correct data
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(FrameCacheTest, FrameCache_Prefetch_PopulatesCache)
+{
+    // Arrange
+    constexpr long N = 2;
+    TestFrameBuilder builder(N);
+    builder.addFrame({{1.f, 2.f, 3.f, 0.f}, {4.f, 5.f, 6.f, 1.f}});
+    builder.addFrame({{7.f, 8.f, 9.f, 0.f}, {10.f, 11.f, 12.f, 1.f}});
+    builder.addFrame({{13.f, 14.f, 15.f, 0.f}, {16.f, 17.f, 18.f, 1.f}});
+    std::string path = builder.writeToTempFile("_fc_prefetch.bin");
+
+    SettingsIO sio;
+    sio.posName = path;
+    sio.N = N;
+    sio.frames = 3;
+
+    constexpr std::size_t maxBytes = 10 * sizeof(glm::vec4);
+    FrameCache cache(sio, maxBytes, executor_);
+
+    // Act — SynchronousExecutor runs tasks inline, so cache is populated immediately
+    cache.prefetch(0, 2, 3);
+
+    // Assert
+    auto frame1 = cache.getFrame(1);
+    auto frame2 = cache.getFrame(2);
+
+    ASSERT_NE(frame1, nullptr);
+    ASSERT_NE(frame2, nullptr);
+    EXPECT_EQ(static_cast<long>(frame1->size()), N);
+    EXPECT_EQ(static_cast<long>(frame2->size()), N);
+
+    std::remove(path.c_str());
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 3. getFrame hit returns the same shared_ptr (pointer identity)
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(FrameCacheTest, FrameCache_GetFrame_HitReturnsSamePointer)
+{
+    // Arrange
+    constexpr long N = 2;
+    TestFrameBuilder builder(N);
+    builder.addFrame({{1.f, 2.f, 3.f, 0.f}, {4.f, 5.f, 6.f, 1.f}});
+    builder.addFrame({{7.f, 8.f, 9.f, 0.f}, {10.f, 11.f, 12.f, 1.f}});
+    std::string path = builder.writeToTempFile("_fc_hit.bin");
+
+    SettingsIO sio;
+    sio.posName = path;
+    sio.N = N;
+    sio.frames = 2;
+
+    constexpr std::size_t maxBytes = 10 * sizeof(glm::vec4);
+    FrameCache cache(sio, maxBytes, executor_);
+    cache.prefetch(0, 1, 2);
+
+    // Act
+    auto first = cache.getFrame(1);
+    auto second = cache.getFrame(1);
+
+    // Assert — same object in memory
+    ASSERT_NE(first, nullptr);
+    EXPECT_EQ(first.get(), second.get());
+
+    std::remove(path.c_str());
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 4. LRU eviction evicts the least-recently-used entry
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(FrameCacheTest, FrameCache_LRUEviction_EvictsLeastRecentlyUsed)
+{
+    // Arrange: 4-frame file, N=1, cap = 2 frames
+    constexpr long N = 1;
+    TestFrameBuilder builder(N);
+    builder.addFrame({{0.f, 0.f, 0.f, 0.f}});
+    builder.addFrame({{1.f, 1.f, 1.f, 0.f}});
+    builder.addFrame({{2.f, 2.f, 2.f, 0.f}});
+    builder.addFrame({{3.f, 3.f, 3.f, 0.f}});
+    std::string path = builder.writeToTempFile("_fc_lru.bin");
+
+    SettingsIO sio;
+    sio.posName = path;
+    sio.N = N;
+    sio.frames = 4;
+
+    // max = 2 * sizeof(glm::vec4) / sizeof(glm::vec4) = 2 frames
+    const std::size_t maxBytes = 2 * sizeof(glm::vec4);
+    FrameCache cache(sio, maxBytes, executor_);
+
+    // Act: prefetch frames 1 and 2 (fills cap)
+    cache.prefetch(0, 2, 4);
+    ASSERT_NE(cache.getFrame(1), nullptr);
+    ASSERT_NE(cache.getFrame(2), nullptr);
+
+    // Access frame 1 to make it MRU (frame 2 becomes LRU)
+    cache.getFrame(1);
+
+    // Prefetch frame 3 — should evict frame 2 (LRU)
+    cache.prefetch(2, 1, 4);
+
+    // Assert
+    EXPECT_NE(cache.getFrame(1), nullptr) << "frame 1 (MRU) should still be cached";
+    EXPECT_EQ(cache.getFrame(2), nullptr) << "frame 2 (LRU) should have been evicted";
+    EXPECT_NE(cache.getFrame(3), nullptr) << "frame 3 (just loaded) should be cached";
+
+    std::remove(path.c_str());
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 5. Cache never exceeds max_frames count
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(FrameCacheTest, FrameCache_LRUEviction_MaxFramesEnforced)
+{
+    // Arrange: 6-frame file, N=1, cap = 3 frames
+    constexpr long N = 1;
+    constexpr long totalFrames = 6;
+    TestFrameBuilder builder(N);
+    for (long i = 0; i < totalFrames; ++i) {
+        builder.addFrame({{static_cast<float>(i), 0.f, 0.f, 0.f}});
+    }
+    std::string path = builder.writeToTempFile("_fc_maxframes.bin");
+
+    SettingsIO sio;
+    sio.posName = path;
+    sio.N = N;
+    sio.frames = totalFrames;
+
+    const std::size_t maxBytes = 3 * sizeof(glm::vec4);
+    FrameCache cache(sio, maxBytes, executor_);
+
+    // Act: prefetch with window larger than cap
+    cache.prefetch(0, 5, totalFrames);
+
+    // Assert: count how many frames are cached (at most 3)
+    int cachedCount = 0;
+    for (long f = 1; f < totalFrames; ++f) {
+        if (cache.getFrame(f) != nullptr) {
+            ++cachedCount;
+        }
+    }
+    EXPECT_EQ(cachedCount, 3) << "cache must hold exactly max_frames entries";
+
+    std::remove(path.c_str());
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 6. clear() erases all cached entries
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(FrameCacheTest, FrameCache_Clear_ErasesCache)
+{
+    // Arrange
+    constexpr long N = 2;
+    TestFrameBuilder builder(N);
+    builder.addFrame({{1.f, 2.f, 3.f, 0.f}, {4.f, 5.f, 6.f, 1.f}});
+    builder.addFrame({{7.f, 8.f, 9.f, 0.f}, {10.f, 11.f, 12.f, 1.f}});
+    std::string path = builder.writeToTempFile("_fc_clear.bin");
+
+    SettingsIO sio;
+    sio.posName = path;
+    sio.N = N;
+    sio.frames = 2;
+
+    constexpr std::size_t maxBytes = 10 * sizeof(glm::vec4);
+    FrameCache cache(sio, maxBytes, executor_);
+    cache.prefetch(0, 1, 2);
+    ASSERT_NE(cache.getFrame(1), nullptr) << "precondition: frame 1 should be cached";
+
+    // Act
+    cache.clear();
+
+    // Assert
+    EXPECT_EQ(cache.getFrame(1), nullptr) << "after clear(), frame 1 must not be in cache";
+
+    std::remove(path.c_str());
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 7. prefetch with zero total_frames must not crash
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(FrameCacheTest, FrameCache_Prefetch_ZeroTotalFrames_DoesNothing)
+{
+    // Arrange
+    SettingsIO sio;
+    sio.N = 2;
+    sio.frames = 0;
+
+    constexpr std::size_t maxBytes = 10 * sizeof(glm::vec4);
+    FrameCache cache(sio, maxBytes, executor_);
+
+    // Act + Assert: must not crash
+    EXPECT_NO_FATAL_FAILURE(cache.prefetch(0, 64, 0));
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 8. pending set prevents duplicate enqueue
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(FrameCacheTest, FrameCache_Prefetch_NoDuplicateEnqueue)
+{
+    // Arrange: CountingExecutor does NOT run tasks, so pending set stays populated
+    constexpr long N = 2;
+    TestFrameBuilder builder(N);
+    builder.addFrame({{1.f, 2.f, 3.f, 0.f}, {4.f, 5.f, 6.f, 1.f}});
+    builder.addFrame({{7.f, 8.f, 9.f, 0.f}, {10.f, 11.f, 12.f, 1.f}});
+    builder.addFrame({{13.f, 14.f, 15.f, 0.f}, {16.f, 17.f, 18.f, 1.f}});
+    std::string path = builder.writeToTempFile("_fc_nodup.bin");
+
+    SettingsIO sio;
+    sio.posName = path;
+    sio.N = N;
+    sio.frames = 3;
+
+    constexpr std::size_t maxBytes = 10 * sizeof(glm::vec4);
+    CountingExecutor counter;
+    FrameCache cache(sio, maxBytes, counter);
+
+    // Act: prefetch twice — second call should not re-enqueue already-pending frames
+    cache.prefetch(0, 2, 3); // enqueues frames 1 and 2 → count = 2
+    cache.prefetch(0, 2, 3); // frames 1 and 2 still pending → count stays 2
+
+    // Assert
+    EXPECT_EQ(counter.callCount, 2) << "pending set must prevent duplicate enqueue";
+
+    std::remove(path.c_str());
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 9. zero-capacity cache never stores any frame
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(FrameCacheTest, FrameCache_ZeroCapacity_NeverCaches)
+{
+    // Arrange: max_frame_bytes < one frame → max_frames_ rounds to 0
+    constexpr long N = 2;
+    TestFrameBuilder builder(N);
+    builder.addFrame({{1.f, 2.f, 3.f, 0.f}, {4.f, 5.f, 6.f, 1.f}});
+    builder.addFrame({{7.f, 8.f, 9.f, 0.f}, {10.f, 11.f, 12.f, 1.f}});
+    std::string path = builder.writeToTempFile("_fc_zerocap.bin");
+
+    SettingsIO sio;
+    sio.posName = path;
+    sio.N = N;
+    sio.frames = 2;
+
+    // Budget: 1 byte — far smaller than one frame (2 × 16 = 32 bytes)
+    constexpr std::size_t maxBytes = 1;
+    FrameCache cache(sio, maxBytes, executor_);
+
+    // Act: attempt to prefetch
+    cache.prefetch(0, 1, 2);
+
+    // Assert: nothing should be cached
+    EXPECT_EQ(cache.getFrame(1), nullptr) << "zero-capacity cache must never store frames";
+
+    std::remove(path.c_str());
+}

--- a/tests/core/MassParamsTests.cpp
+++ b/tests/core/MassParamsTests.cpp
@@ -1,0 +1,46 @@
+// Include glad first to avoid OpenGL header conflicts
+#include <glad/glad.h>
+#include <gtest/gtest.h>
+
+#include "MassParams.hpp"
+#include "settingsIO.hpp"
+
+class MassParamsTest : public ::testing::Test
+{
+};
+
+TEST_F(MassParamsTest, AggregateInit_SetsAllFields)
+{
+    // Arrange / Act
+    MassParams mp{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0};
+
+    // Assert
+    EXPECT_EQ(mp.fraction_earth_mass_of_body1, 1.0);
+    EXPECT_EQ(mp.fraction_earth_mass_of_body2, 2.0);
+    EXPECT_EQ(mp.fraction_fe_body1, 3.0);
+    EXPECT_EQ(mp.fraction_si_body1, 4.0);
+    EXPECT_EQ(mp.fraction_fe_body2, 5.0);
+    EXPECT_EQ(mp.fraction_si_body2, 6.0);
+    EXPECT_EQ(mp.mass_of_earth, 7.0);
+}
+
+TEST_F(MassParamsTest, FromSettingsIO_PopulatesAllFields)
+{
+    constexpr double kSettingsIOSentinel = 100.0; // SettingsIO fallback when file not found
+
+    // Arrange — 3-arg constructor with non-existent path sets all mass fields to 100
+    // (the else-branch fallback in SettingsIO sets sentinel value 100 for all fields)
+    SettingsIO sio("/nonexistent/pos", "/nonexistent/stats", "/nonexistent/com");
+
+    // Act
+    MassParams mp = MassParams::fromSettingsIO(sio);
+
+    // Assert
+    EXPECT_EQ(mp.fraction_earth_mass_of_body1, kSettingsIOSentinel);
+    EXPECT_EQ(mp.fraction_earth_mass_of_body2, kSettingsIOSentinel);
+    EXPECT_EQ(mp.fraction_fe_body1, kSettingsIOSentinel);
+    EXPECT_EQ(mp.fraction_si_body1, kSettingsIOSentinel);
+    EXPECT_EQ(mp.fraction_fe_body2, kSettingsIOSentinel);
+    EXPECT_EQ(mp.fraction_si_body2, kSettingsIOSentinel);
+    EXPECT_EQ(mp.mass_of_earth, kSettingsIOSentinel);
+}

--- a/tests/core/MassParamsTests.cpp
+++ b/tests/core/MassParamsTests.cpp
@@ -24,6 +24,25 @@ TEST_F(MassParamsTest, AggregateInit_SetsAllFields)
     EXPECT_EQ(mp.mass_of_earth, 7.0);
 }
 
+TEST_F(MassParamsTest, FromSettingsIO_DefaultSettingsIO_ReturnsZeroParams)
+{
+    // Arrange — default SettingsIO has no stats file loaded; mass-fraction fields
+    // must be zero-initialised by the default constructor (not left uninitialised).
+    SettingsIO sio; // zero-arg constructor
+
+    // Act
+    MassParams mp = MassParams::fromSettingsIO(sio);
+
+    // Assert — well-defined zero values, not garbage from uninitialised memory
+    EXPECT_EQ(mp.fraction_earth_mass_of_body1, 0.0);
+    EXPECT_EQ(mp.fraction_earth_mass_of_body2, 0.0);
+    EXPECT_EQ(mp.fraction_fe_body1, 0.0);
+    EXPECT_EQ(mp.fraction_si_body1, 0.0);
+    EXPECT_EQ(mp.fraction_fe_body2, 0.0);
+    EXPECT_EQ(mp.fraction_si_body2, 0.0);
+    EXPECT_EQ(mp.mass_of_earth, 0.0);
+}
+
 TEST_F(MassParamsTest, FromSettingsIO_PopulatesAllFields)
 {
     constexpr double kSettingsIOSentinel = 100.0; // SettingsIO fallback when file not found

--- a/tests/core/MockCOMProviderTests.cpp
+++ b/tests/core/MockCOMProviderTests.cpp
@@ -1,0 +1,54 @@
+/*
+ * MockCOMProviderTests.cpp
+ *
+ * Contract tests for MockCOMProvider — verifies the mock correctly implements
+ * the ICOMProvider interface: preset values are returned on hit, out parameter
+ * is left unchanged on miss, and frame isolation is enforced.
+ */
+
+#include <gtest/gtest.h>
+
+#include <glm/glm.hpp>
+
+#include "MockCOMProvider.hpp"
+
+TEST(MockCOMProviderTest, UnsetFrame_ReturnsFalse)
+{
+    MockCOMProvider provider;
+    glm::vec3 out{99.0f, 99.0f, 99.0f};
+
+    bool result = provider.getCOM(0, out);
+
+    EXPECT_FALSE(result);
+    EXPECT_FLOAT_EQ(out.x, 99.0f);
+    EXPECT_FLOAT_EQ(out.y, 99.0f);
+    EXPECT_FLOAT_EQ(out.z, 99.0f);
+}
+
+TEST(MockCOMProviderTest, SetFrame_ReturnsTrue)
+{
+    MockCOMProvider provider;
+    provider.setCOM(5, glm::vec3{1.0f, 2.0f, 3.0f});
+    glm::vec3 out{0.0f, 0.0f, 0.0f};
+
+    bool result = provider.getCOM(5, out);
+
+    EXPECT_TRUE(result);
+    EXPECT_FLOAT_EQ(out.x, 1.0f);
+    EXPECT_FLOAT_EQ(out.y, 2.0f);
+    EXPECT_FLOAT_EQ(out.z, 3.0f);
+}
+
+TEST(MockCOMProviderTest, UnsetFrame_AfterOtherFrameSet_ReturnsFalse)
+{
+    MockCOMProvider provider;
+    provider.setCOM(5, glm::vec3{1.0f, 2.0f, 3.0f});
+    glm::vec3 out{7.0f, 7.0f, 7.0f};
+
+    bool result = provider.getCOM(99, out);
+
+    EXPECT_FALSE(result);
+    EXPECT_FLOAT_EQ(out.x, 7.0f);
+    EXPECT_FLOAT_EQ(out.y, 7.0f);
+    EXPECT_FLOAT_EQ(out.z, 7.0f);
+}

--- a/tests/core/ReadPosBufferTests.cpp
+++ b/tests/core/ReadPosBufferTests.cpp
@@ -1,0 +1,286 @@
+/*
+ * ReadPosBufferTests.cpp
+ *
+ * Unit tests for SettingsIO::readPosBuffer — GL-free disk reader.
+ */
+
+#include <cstdio>
+#include <vector>
+
+// Include glad first to avoid OpenGL header conflicts
+#include <glad/glad.h>
+#include <gtest/gtest.h>
+
+#include <glm/glm.hpp>
+
+#include "MockOpenGL.hpp"
+#include "settingsIO.hpp"
+#include "testing/TestFrameBuilder.hpp"
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+class ReadPosBufferTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        MockOpenGL::reset();
+        MockOpenGL::initGLAD();
+    }
+};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Single-frame: returns correct positions at frame 0
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(ReadPosBufferTest, ReadPosBuffer_ValidFrame0_ReturnsCorrectPositions)
+{
+    constexpr long N = 3;
+    std::vector<glm::vec4> pos0 = {
+        {1.f, 2.f, 3.f, 0.f},
+        {4.f, 5.f, 6.f, 1.f},
+        {7.f, 8.f, 9.f, 2.f},
+    };
+
+    TestFrameBuilder builder(N);
+    builder.addFrame(pos0);
+    std::string path = builder.writeToTempFile("_read_pos_frame0.bin");
+
+    SettingsIO sio;
+    sio.posName = path;
+    sio.N = N;
+    sio.frames = 1;
+
+    auto result = sio.readPosBuffer(0);
+    ASSERT_EQ(static_cast<long>(result.size()), N);
+    for (long i = 0; i < N; ++i) {
+        EXPECT_FLOAT_EQ(result[i].x, pos0[i].x);
+        EXPECT_FLOAT_EQ(result[i].y, pos0[i].y);
+        EXPECT_FLOAT_EQ(result[i].z, pos0[i].z);
+        EXPECT_FLOAT_EQ(result[i].w, pos0[i].w);
+    }
+
+    std::remove(path.c_str());
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Multi-frame: frame 0 and frame 1 return independent correct data
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(ReadPosBufferTest, ReadPosBuffer_MultiFrame_IndependentFrames)
+{
+    constexpr long N = 2;
+    std::vector<glm::vec4> pos0 = {{10.f, 20.f, 30.f, 0.f}, {40.f, 50.f, 60.f, 1.f}};
+    std::vector<glm::vec4> pos1 = {{-1.f, -2.f, -3.f, 0.f}, {-4.f, -5.f, -6.f, 1.f}};
+
+    TestFrameBuilder builder(N);
+    builder.addFrame(pos0);
+    builder.addFrame(pos1);
+    std::string path = builder.writeToTempFile("_read_pos_multiframe.bin");
+
+    SettingsIO sio;
+    sio.posName = path;
+    sio.N = N;
+    sio.frames = 2;
+
+    auto result0 = sio.readPosBuffer(0);
+    ASSERT_EQ(static_cast<long>(result0.size()), N);
+    for (long i = 0; i < N; ++i) {
+        EXPECT_FLOAT_EQ(result0[i].x, pos0[i].x);
+        EXPECT_FLOAT_EQ(result0[i].y, pos0[i].y);
+        EXPECT_FLOAT_EQ(result0[i].z, pos0[i].z);
+        EXPECT_FLOAT_EQ(result0[i].w, pos0[i].w);
+    }
+
+    auto result1 = sio.readPosBuffer(1);
+    ASSERT_EQ(static_cast<long>(result1.size()), N);
+    for (long i = 0; i < N; ++i) {
+        EXPECT_FLOAT_EQ(result1[i].x, pos1[i].x);
+        EXPECT_FLOAT_EQ(result1[i].y, pos1[i].y);
+        EXPECT_FLOAT_EQ(result1[i].z, pos1[i].z);
+        EXPECT_FLOAT_EQ(result1[i].w, pos1[i].w);
+    }
+
+    std::remove(path.c_str());
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Error handling: invalid path returns empty vector
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(ReadPosBufferTest, ReadPosBuffer_InvalidPath_ReturnsEmptyVector)
+{
+    SettingsIO sio;
+    sio.posName = "/nonexistent/path/read_pos_buffer_invalid.bin";
+    sio.N = 3;
+    sio.frames = 1;
+
+    auto result = sio.readPosBuffer(0);
+    EXPECT_TRUE(result.empty());
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// N=0 returns empty vector without crashing
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(ReadPosBufferTest, ReadPosBuffer_NEqualsZero_ReturnsEmptyVector)
+{
+    SettingsIO sio;
+    sio.posName = "/nonexistent/path/that_cannot_exist.bin";
+    sio.N = 0;
+    sio.frames = 1;
+
+    auto result = sio.readPosBuffer(0);
+    EXPECT_TRUE(result.empty());
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Frame clamping: readPosBuffer(-1) returns frame 0 data
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(ReadPosBufferTest, ReadPosBuffer_NegativeFrame_ClampedToFrame0)
+{
+    constexpr long N = 2;
+    std::vector<glm::vec4> pos0 = {{1.f, 2.f, 3.f, 4.f}, {5.f, 6.f, 7.f, 8.f}};
+
+    TestFrameBuilder builder(N);
+    builder.addFrame(pos0);
+    std::string path = builder.writeToTempFile("_read_pos_clamp_neg.bin");
+
+    SettingsIO sio;
+    sio.posName = path;
+    sio.N = N;
+    sio.frames = 1;
+
+    auto result = sio.readPosBuffer(-1);
+    ASSERT_EQ(static_cast<long>(result.size()), N);
+    EXPECT_FLOAT_EQ(result[0].x, pos0[0].x);
+    EXPECT_FLOAT_EQ(result[0].y, pos0[0].y);
+    EXPECT_FLOAT_EQ(result[0].z, pos0[0].z);
+    EXPECT_FLOAT_EQ(result[0].w, pos0[0].w);
+    EXPECT_FLOAT_EQ(result[1].x, pos0[1].x);
+    EXPECT_FLOAT_EQ(result[1].y, pos0[1].y);
+    EXPECT_FLOAT_EQ(result[1].z, pos0[1].z);
+    EXPECT_FLOAT_EQ(result[1].w, pos0[1].w);
+
+    std::remove(path.c_str());
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Frame clamping: readPosBuffer(999) on a 1-frame file returns frame 0 data
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(ReadPosBufferTest, ReadPosBuffer_OOBFrame_ClampedToLastFrame)
+{
+    constexpr long N = 2;
+    std::vector<glm::vec4> pos0 = {{5.f, 6.f, 7.f, 0.f}, {8.f, 9.f, 10.f, 1.f}};
+
+    TestFrameBuilder builder(N);
+    builder.addFrame(pos0);
+    std::string path = builder.writeToTempFile("_read_pos_clamp_over.bin");
+
+    SettingsIO sio;
+    sio.posName = path;
+    sio.N = N;
+    sio.frames = 1;
+
+    auto result = sio.readPosBuffer(999);
+    ASSERT_EQ(static_cast<long>(result.size()), N);
+    EXPECT_FLOAT_EQ(result[0].x, pos0[0].x);
+    EXPECT_FLOAT_EQ(result[0].y, pos0[0].y);
+    EXPECT_FLOAT_EQ(result[0].z, pos0[0].z);
+    EXPECT_FLOAT_EQ(result[0].w, pos0[0].w);
+    EXPECT_FLOAT_EQ(result[1].x, pos0[1].x);
+    EXPECT_FLOAT_EQ(result[1].y, pos0[1].y);
+    EXPECT_FLOAT_EQ(result[1].z, pos0[1].z);
+    EXPECT_FLOAT_EQ(result[1].w, pos0[1].w);
+
+    std::remove(path.c_str());
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// frames=0 returns empty vector without crashing
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(ReadPosBufferTest, ReadPosBuffer_FramesEqualsZero_ReturnsEmptyVector)
+{
+    SettingsIO sio;
+    sio.posName = "/nonexistent/path/that_cannot_exist.bin";
+    sio.N = 3;
+    sio.frames = 0;
+
+    auto result = sio.readPosBuffer(0);
+    EXPECT_TRUE(result.empty());
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Does NOT mutate isPlaying on negative out-of-range frame
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(ReadPosBufferTest, ReadPosBuffer_NegativeFrame_DoesNotMutateIsPlaying)
+{
+    constexpr long N = 1;
+    std::vector<glm::vec4> pos0 = {{1.f, 2.f, 3.f, 0.f}};
+
+    TestFrameBuilder builder(N);
+    builder.addFrame(pos0);
+    std::string path = builder.writeToTempFile("_read_pos_isplaying_neg.bin");
+
+    SettingsIO sio;
+    sio.posName = path;
+    sio.N = N;
+    sio.frames = 1;
+    sio.isPlaying = false;
+    sio.errorCount = 0;
+
+    sio.readPosBuffer(-1);
+    EXPECT_FALSE(sio.isPlaying) << "readPosBuffer must not mutate isPlaying";
+    EXPECT_EQ(sio.errorCount, 0) << "readPosBuffer must not mutate errorCount";
+
+    std::remove(path.c_str());
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Does NOT mutate isPlaying on positive out-of-bounds frame
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(ReadPosBufferTest, ReadPosBuffer_PositiveOOBFrame_DoesNotMutateIsPlaying)
+{
+    constexpr long N = 1;
+    std::vector<glm::vec4> pos0 = {{1.f, 2.f, 3.f, 0.f}};
+
+    TestFrameBuilder builder(N);
+    builder.addFrame(pos0);
+    std::string path = builder.writeToTempFile("_read_pos_isplaying_oob.bin");
+
+    SettingsIO sio;
+    sio.posName = path;
+    sio.N = N;
+    sio.frames = 1;
+    sio.isPlaying = true;
+    sio.errorCount = 0;
+
+    sio.readPosBuffer(999);
+    EXPECT_TRUE(sio.isPlaying) << "readPosBuffer must not mutate isPlaying";
+    EXPECT_EQ(sio.errorCount, 0) << "readPosBuffer must not mutate errorCount";
+
+    std::remove(path.c_str());
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Does NOT mutate errorCount on error
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(ReadPosBufferTest, ReadPosBuffer_InvalidPath_DoesNotMutateErrorCount)
+{
+    SettingsIO sio;
+    sio.posName = "/nonexistent/path/read_pos_buffer_errorcount.bin";
+    sio.N = 3;
+    sio.frames = 1;
+    sio.errorCount = 0;
+
+    sio.readPosBuffer(0);
+    EXPECT_EQ(sio.errorCount, 0) << "readPosBuffer must not mutate errorCount";
+}

--- a/tests/core/SettingsIOTests.cpp
+++ b/tests/core/SettingsIOTests.cpp
@@ -593,7 +593,127 @@ TEST_F(SettingsIOTest, GetFrames_MultipleCallsReturnSameValue)
     EXPECT_EQ(frames1, frames2);
 }
 
-// ─── checkCOM tests ───────────────────────────────────────────────────────────
+// ─── getCOM tests ─────────────────────────────────────────────────────────────
+// getCOM() reads a glm::vec4 record for the given frame using an absolute
+// file offset (SEEK_SET). The .w field must equal the frame index; .x/.y/.z
+// are scaled by kSimToDisplayScale before being written to the out-param.
+
+TEST_F(SettingsIOTest, GetCOM_MissingFile_ReturnsFalse)
+{
+    // Arrange
+    SettingsIO settings;
+    settings.comName = "/tmp/no_com_file_xyz_does_not_exist.bin";
+    glm::vec3 value(0.f);
+
+    // Act & Assert
+    EXPECT_FALSE(settings.getCOM(0, value));
+    EXPECT_EQ(value, glm::vec3(0.f));
+}
+
+TEST_F(SettingsIOTest, GetCOM_ValidFile_Frame0_ReturnsTrue)
+{
+    // Arrange: write a 2-frame COMFile; each record is vec4(x, y, z, frame_index)
+    const std::string comPath = "/tmp/test_getCOM_frame0.bin";
+    FILE* f = fopen(comPath.c_str(), "wb");
+    ASSERT_NE(f, nullptr);
+    const glm::vec4 frame0(1.0f, 2.0f, 3.0f, 0.0f);
+    const glm::vec4 frame1(4.0f, 5.0f, 6.0f, 1.0f);
+    fwrite(&frame0, sizeof(glm::vec4), 1, f);
+    fwrite(&frame1, sizeof(glm::vec4), 1, f);
+    fclose(f);
+
+    SettingsIO settings;
+    settings.comName = comPath;
+    glm::vec3 value(0.f);
+
+    // Act & Assert
+    EXPECT_TRUE(settings.getCOM(0, value));
+    std::remove(comPath.c_str());
+}
+
+TEST_F(SettingsIOTest, GetCOM_ValidFile_Frame0_ScalesOutput)
+{
+    // Arrange
+    const std::string comPath = "/tmp/test_getCOM_scale.bin";
+    FILE* f = fopen(comPath.c_str(), "wb");
+    ASSERT_NE(f, nullptr);
+    const glm::vec4 frame0(4.0f, 8.0f, 12.0f, 0.0f);
+    fwrite(&frame0, sizeof(glm::vec4), 1, f);
+    fclose(f);
+
+    SettingsIO settings;
+    settings.comName = comPath;
+    glm::vec3 value(0.f);
+    ASSERT_TRUE(settings.getCOM(0, value));
+
+    // kSimToDisplayScale = 0.25f
+    EXPECT_FLOAT_EQ(value.x, 4.0f * 0.25f);
+    EXPECT_FLOAT_EQ(value.y, 8.0f * 0.25f);
+    EXPECT_FLOAT_EQ(value.z, 12.0f * 0.25f);
+    std::remove(comPath.c_str());
+}
+
+TEST_F(SettingsIOTest, GetCOM_ValidFile_Frame1_SeekIsAbsolute)
+{
+    // Arrange: absolute seek to frame 1 must skip frame 0 record exactly
+    const std::string comPath = "/tmp/test_getCOM_frame1.bin";
+    FILE* f = fopen(comPath.c_str(), "wb");
+    ASSERT_NE(f, nullptr);
+    const glm::vec4 frame0(1.0f, 2.0f, 3.0f, 0.0f);
+    const glm::vec4 frame1(4.0f, 5.0f, 6.0f, 1.0f);
+    fwrite(&frame0, sizeof(glm::vec4), 1, f);
+    fwrite(&frame1, sizeof(glm::vec4), 1, f);
+    fclose(f);
+
+    SettingsIO settings;
+    settings.comName = comPath;
+    glm::vec3 value(0.f);
+
+    // Act & Assert
+    EXPECT_TRUE(settings.getCOM(1, value));
+    std::remove(comPath.c_str());
+}
+
+TEST_F(SettingsIOTest, GetCOM_TruncatedFile_Frame1_ReturnsFalse)
+{
+    // Arrange: file has only 1 record; requesting frame 1 seeks past EOF
+    const std::string comPath = "/tmp/test_getCOM_truncated.bin";
+    FILE* f = fopen(comPath.c_str(), "wb");
+    ASSERT_NE(f, nullptr);
+    const glm::vec4 frame0(1.0f, 2.0f, 3.0f, 0.0f);
+    fwrite(&frame0, sizeof(glm::vec4), 1, f);
+    fclose(f);
+
+    SettingsIO settings;
+    settings.comName = comPath;
+    glm::vec3 value(0.f);
+
+    // Act & Assert — fread returns 0 items → returns false; value must be unchanged
+    EXPECT_FALSE(settings.getCOM(1, value));
+    EXPECT_EQ(value, glm::vec3(0.f));
+    std::remove(comPath.c_str());
+}
+
+TEST_F(SettingsIOTest, GetCOM_WrongFrameIndex_ReturnsFalse)
+{
+    // Arrange: record at offset 0 has .w=99 (mismatch with requested frame 0)
+    const std::string comPath = "/tmp/test_getCOM_mismatch.bin";
+    FILE* f = fopen(comPath.c_str(), "wb");
+    ASSERT_NE(f, nullptr);
+    const glm::vec4 badRecord(1.0f, 2.0f, 3.0f, 99.0f); // .w != 0
+    fwrite(&badRecord, sizeof(glm::vec4), 1, f);
+    fclose(f);
+
+    SettingsIO settings;
+    settings.comName = comPath;
+    glm::vec3 value(0.f);
+
+    // Act & Assert — frame index mismatch → returns false; value must be unchanged
+    EXPECT_FALSE(settings.getCOM(0, value));
+    EXPECT_EQ(value, glm::vec3(0.f));
+    std::remove(comPath.c_str());
+}
+
 // checkCOM() is used in the COM prefetch guard: the run loop must suppress
 // async COM computation when a COMFile is already present on disk.
 

--- a/tests/core/SettingsIOTests.cpp
+++ b/tests/core/SettingsIOTests.cpp
@@ -592,3 +592,33 @@ TEST_F(SettingsIOTest, GetFrames_MultipleCallsReturnSameValue)
     // Assert
     EXPECT_EQ(frames1, frames2);
 }
+
+// ─── checkCOM tests ───────────────────────────────────────────────────────────
+// checkCOM() is used in the COM prefetch guard: the run loop must suppress
+// async COM computation when a COMFile is already present on disk.
+
+TEST_F(SettingsIOTest, CheckCOM_WithExistingCOMFile_ReturnsTrue)
+{
+    // Arrange
+    SettingsIO settings;
+    settings.comName = validComPath;
+
+    // Act
+    bool result = settings.checkCOM();
+
+    // Assert
+    EXPECT_TRUE(result);
+}
+
+TEST_F(SettingsIOTest, CheckCOM_WithMissingCOMFile_ReturnsFalse)
+{
+    // Arrange
+    SettingsIO settings;
+    settings.comName = "/tmp/no_com_file_xyz_does_not_exist.bin";
+
+    // Act
+    bool result = settings.checkCOM();
+
+    // Assert
+    EXPECT_FALSE(result);
+}

--- a/tests/core/StageTranslationsTests.cpp
+++ b/tests/core/StageTranslationsTests.cpp
@@ -1,0 +1,185 @@
+/*
+ * StageTranslationsTests.cpp
+ *
+ * Unit tests for Particle::stageTranslations — CPU-only staging method
+ * that copies position data without making any GL calls.
+ */
+
+// Include glad first to avoid OpenGL header conflicts
+#include <vector>
+
+#include <glad/glad.h>
+#include <gtest/gtest.h>
+
+#include <glm/glm.hpp>
+
+#include "MockOpenGL.hpp"
+#include "particle.hpp"
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+static void expectEqVec4(const glm::vec4& actual, const glm::vec4& expected)
+{
+    EXPECT_FLOAT_EQ(actual.x, expected.x);
+    EXPECT_FLOAT_EQ(actual.y, expected.y);
+    EXPECT_FLOAT_EQ(actual.z, expected.z);
+    EXPECT_FLOAT_EQ(actual.w, expected.w);
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Test fixture
+// ──────────────────────────────────────────────────────────────────────────────
+
+class StageTranslationsTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        MockOpenGL::reset();
+        MockOpenGL::initGLAD();
+    }
+};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Valid data: copies positions and sets n
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(StageTranslationsTest, StageTranslations_ValidData_CopiesIntoTranslations)
+{
+    // Arrange
+    constexpr long N = 3;
+    std::vector<glm::vec4> initial(1, glm::vec4(0.f));
+    Particle p(1, initial.data());
+
+    std::vector<glm::vec4> data = {
+        {1.f, 2.f, 3.f, 4.f},
+        {5.f, 6.f, 7.f, 8.f},
+        {9.f, 10.f, 11.f, 12.f},
+    };
+
+    // Act
+    p.stageTranslations(data.data(), N);
+
+    // Assert
+    ASSERT_EQ(static_cast<long>(p.translations.size()), N);
+    EXPECT_EQ(p.n, N);
+    expectEqVec4(p.translations[0], glm::vec4(1.f, 2.f, 3.f, 4.f));
+    expectEqVec4(p.translations[1], glm::vec4(5.f, 6.f, 7.f, 8.f));
+    expectEqVec4(p.translations[2], glm::vec4(9.f, 10.f, 11.f, 12.f));
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Null data: no-op
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(StageTranslationsTest, StageTranslations_NullData_DoesNothing)
+{
+    // Arrange
+    constexpr long N = 2;
+    std::vector<glm::vec4> initial = {{1.f, 1.f, 1.f, 1.f}, {2.f, 2.f, 2.f, 2.f}};
+    Particle p(N, initial.data());
+
+    // Act
+    p.stageTranslations(nullptr, N);
+
+    // Assert
+    EXPECT_EQ(p.n, N);
+    ASSERT_EQ(static_cast<long>(p.translations.size()), N);
+    expectEqVec4(p.translations[0], glm::vec4(1.f, 1.f, 1.f, 1.f));
+    expectEqVec4(p.translations[1], glm::vec4(2.f, 2.f, 2.f, 2.f));
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// N <= 0: no-op
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(StageTranslationsTest, StageTranslations_ZeroN_DoesNothing)
+{
+    // Arrange
+    constexpr long N = 2;
+    std::vector<glm::vec4> initial = {{3.f, 3.f, 3.f, 3.f}, {4.f, 4.f, 4.f, 4.f}};
+    Particle p(N, initial.data());
+
+    std::vector<glm::vec4> newData = {{9.f, 9.f, 9.f, 9.f}, {8.f, 8.f, 8.f, 8.f}};
+
+    // Act
+    p.stageTranslations(newData.data(), 0);
+
+    // Assert
+    EXPECT_EQ(p.n, N);
+    ASSERT_EQ(static_cast<long>(p.translations.size()), N);
+    expectEqVec4(p.translations[0], glm::vec4(3.f, 3.f, 3.f, 3.f));
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Updates n to match staged count
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(StageTranslationsTest, StageTranslations_UpdatesN)
+{
+    // Arrange
+    constexpr long initial_n = 1;
+    constexpr long staged_n = 7;
+    std::vector<glm::vec4> initial(initial_n, glm::vec4(0.f));
+    Particle p(initial_n, initial.data());
+
+    std::vector<glm::vec4> staged(staged_n, glm::vec4(1.f));
+
+    // Act
+    p.stageTranslations(staged.data(), staged_n);
+
+    // Assert
+    EXPECT_EQ(p.n, staged_n);
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// No GL buffer calls after stageTranslations (pushVBO not called)
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(StageTranslationsTest, StageTranslations_NoGLCalls_AfterStage)
+{
+    // Arrange
+    constexpr long N = 3;
+    std::vector<glm::vec4> initial(N, glm::vec4(0.f));
+    Particle p(N, initial.data());
+
+    // Record the VBO id before staging (set by constructor's setUpInstanceBuffer)
+    GLuint vbo_before = p.instanceVBO;
+
+    // Reset mock counters after construction (we only care about staging calls)
+    MockOpenGL::reset();
+    MockOpenGL::initGLAD();
+
+    std::vector<glm::vec4> staged(N, glm::vec4(2.f));
+
+    // Act — stageTranslations must not invoke any GL calls
+    p.stageTranslations(staged.data(), N);
+
+    // Assert — the VBO handle must be unchanged: no glGenBuffers or glDeleteBuffers ran.
+    // (MockOpenGL does not track buffer call counts; instanceVBO identity is the proxy.)
+    EXPECT_EQ(p.instanceVBO, vbo_before);
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Negative N: no-op (guard covers N <= 0)
+// ──────────────────────────────────────────────────────────────────────────────
+
+TEST_F(StageTranslationsTest, StageTranslations_NegativeN_DoesNothing)
+{
+    // Arrange
+    constexpr long N = 2;
+    std::vector<glm::vec4> initial = {{7.f, 7.f, 7.f, 7.f}, {8.f, 8.f, 8.f, 8.f}};
+    Particle p(N, initial.data());
+
+    std::vector<glm::vec4> newData = {{0.f, 0.f, 0.f, 0.f}};
+
+    // Act — negative N must be treated as a no-op by the N <= 0 guard
+    p.stageTranslations(newData.data(), -1);
+
+    // Assert
+    EXPECT_EQ(p.n, N);
+    ASSERT_EQ(static_cast<long>(p.translations.size()), N);
+    expectEqVec4(p.translations[0], glm::vec4(7.f, 7.f, 7.f, 7.f));
+}

--- a/tests/core/ViewerAppWiringTests.cpp
+++ b/tests/core/ViewerAppWiringTests.cpp
@@ -1,0 +1,75 @@
+/*
+ * ViewerAppWiringTests.cpp
+ *
+ * Structural unit tests verifying that the new fields and getters introduced
+ * by the viewer-app-wiring feature exist and default-initialise correctly.
+ * These tests do NOT instantiate ViewerApp; they test components in isolation.
+ */
+
+// clang-format off
+#include <glad/glad.h>  // NOLINT(llvm-include-order) — must precede GL headers
+// clang-format on
+
+#include <gtest/gtest.h>
+
+#include "MockOpenGL.hpp"
+#include "camera.hpp"
+#include "ui/imgui_menu.hpp"
+
+// ============================================================================
+// MenuState — new fields default-initialise correctly
+// ============================================================================
+
+TEST(ViewerAppWiring_MenuState, AutoComComputeDefaultsFalse)
+{
+    // Arrange & Act
+    MenuState state;
+
+    // Assert
+    EXPECT_FALSE(state.auto_com_compute);
+}
+
+TEST(ViewerAppWiring_MenuState, CacheStatusFramesCachedDefaultsZero)
+{
+    // Arrange & Act
+    MenuState state;
+
+    // Assert
+    EXPECT_EQ(state.cache_status.frames_cached, 0);
+}
+
+TEST(ViewerAppWiring_MenuState, CacheStatusBytesUsedDefaultsZero)
+{
+    // Arrange & Act
+    MenuState state;
+
+    // Assert
+    EXPECT_EQ(state.cache_status.bytes_used, static_cast<std::size_t>(0));
+}
+
+// ============================================================================
+// MenuActions — new field defaults to false
+// ============================================================================
+
+TEST(ViewerAppWiring_MenuActions, ToggleAutoComDefaultsFalse)
+{
+    // Arrange & Act
+    MenuActions actions;
+
+    // Assert
+    EXPECT_FALSE(actions.toggle_auto_com);
+}
+
+// ============================================================================
+// Camera — isComLocked() returns false on construction
+// ============================================================================
+
+TEST(ViewerAppWiring_Camera, IsComLockedReturnsFalseInitially)
+{
+    // Arrange
+    MockOpenGL::reset();
+    Camera camera(800, 600);
+
+    // Act & Assert — comLock starts false; getter must reflect that
+    EXPECT_FALSE(camera.isComLocked());
+}

--- a/tests/core/ViewerConfigTests.cpp
+++ b/tests/core/ViewerConfigTests.cpp
@@ -18,7 +18,7 @@ class ViewerConfigTest : public ::testing::Test
   protected:
     void SetUp() override
     {
-        test_folder = "/tmp/test_particle_viewer_config";
+        test_folder = (std::filesystem::path(::testing::TempDir()) / "test_particle_viewer_config").string();
         std::filesystem::create_directories(test_folder);
         std::filesystem::remove(test_folder + "/viewer.cfg");
     }

--- a/tests/core/ViewerConfigTests.cpp
+++ b/tests/core/ViewerConfigTests.cpp
@@ -4,8 +4,7 @@
  * Unit tests for viewer configuration save/load functionality.
  */
 
-#include <cstdio>
-#include <cstdlib>
+#include <filesystem>
 #include <fstream>
 #include <string>
 
@@ -20,16 +19,13 @@ class ViewerConfigTest : public ::testing::Test
     void SetUp() override
     {
         test_folder = "/tmp/test_particle_viewer_config";
-        // Linux-only: project does not support Windows.
-        std::system(("mkdir -p " + test_folder).c_str());
-        // Clean up any existing viewer.cfg
-        std::remove((test_folder + "/viewer.cfg").c_str());
+        std::filesystem::create_directories(test_folder);
+        std::filesystem::remove(test_folder + "/viewer.cfg");
     }
 
     void TearDown() override
     {
-        // Remove the test directory and its contents
-        std::system(("rm -rf " + test_folder).c_str());
+        std::filesystem::remove_all(test_folder);
     }
 
     std::string test_folder;

--- a/tests/core/ViewerConfigTests.cpp
+++ b/tests/core/ViewerConfigTests.cpp
@@ -1,0 +1,127 @@
+/*
+ * ViewerConfigTests.cpp
+ *
+ * Unit tests for viewer configuration save/load functionality.
+ */
+
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "viewerConfig.hpp"
+
+// Test fixture for ViewerConfig tests
+class ViewerConfigTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        test_folder = "/tmp/test_particle_viewer_config";
+        // Linux-only: project does not support Windows.
+        std::system(("mkdir -p " + test_folder).c_str());
+        // Clean up any existing viewer.cfg
+        std::remove((test_folder + "/viewer.cfg").c_str());
+    }
+
+    void TearDown() override
+    {
+        // Remove the test directory and its contents
+        std::system(("rm -rf " + test_folder).c_str());
+    }
+
+    std::string test_folder;
+};
+
+// ============================================
+// Save Configuration Tests
+// ============================================
+
+TEST_F(ViewerConfigTest, ViewerConfig_Save_ReturnsTrue)
+{
+    // Arrange
+    bool auto_com_compute = true;
+
+    // Act
+    bool result = saveViewerConfig(test_folder, auto_com_compute);
+
+    // Assert
+    EXPECT_TRUE(result);
+}
+
+// ============================================
+// Load Configuration Tests
+// ============================================
+
+TEST_F(ViewerConfigTest, ViewerConfig_Load_TrueValue_RoundsTrip)
+{
+    // Arrange
+    ASSERT_TRUE(saveViewerConfig(test_folder, true));
+
+    // Act
+    bool loaded = false;
+    bool found = loadViewerConfig(test_folder, loaded);
+
+    // Assert
+    EXPECT_TRUE(found);
+    EXPECT_TRUE(loaded);
+}
+
+TEST_F(ViewerConfigTest, ViewerConfig_Load_FalseValue_RoundsTrip)
+{
+    // Arrange
+    ASSERT_TRUE(saveViewerConfig(test_folder, false));
+
+    // Act
+    bool loaded = true; // start with opposite to confirm it's overwritten
+    bool found = loadViewerConfig(test_folder, loaded);
+
+    // Assert
+    EXPECT_TRUE(found);
+    EXPECT_FALSE(loaded);
+}
+
+TEST_F(ViewerConfigTest, ViewerConfig_Load_MissingFile_ReturnsFalse)
+{
+    // Arrange: folder exists but viewer.cfg does not
+    bool auto_com_compute = true;
+
+    // Act
+    bool result = loadViewerConfig(test_folder, auto_com_compute);
+
+    // Assert
+    EXPECT_FALSE(result);
+}
+
+TEST_F(ViewerConfigTest, ViewerConfig_Load_UnknownKeys_AreIgnored)
+{
+    // Arrange: manually write a file with unknown keys plus the known key
+    std::ofstream file(test_folder + "/viewer.cfg");
+    file << "# Particle-Viewer Simulation Configuration\n";
+    file << "unknown_key=42\n";
+    file << "auto_com_compute=0\n";
+    file << "another_unknown=hello\n";
+    file.close();
+
+    // Act
+    bool auto_com_compute = true; // default opposite
+    bool result = loadViewerConfig(test_folder, auto_com_compute);
+
+    // Assert
+    EXPECT_TRUE(result);
+    EXPECT_FALSE(auto_com_compute);
+}
+
+TEST_F(ViewerConfigTest, ViewerConfig_Save_ReadOnly_ReturnsFalse)
+{
+    // Arrange: directory does not exist — save should fail silently
+    std::string nonexistent_folder = "/tmp/nonexistent_dir_xyz";
+
+    // Act
+    bool result = saveViewerConfig(nonexistent_folder, true);
+
+    // Assert
+    EXPECT_FALSE(result);
+}

--- a/tests/core/ViewerConfigTests.cpp
+++ b/tests/core/ViewerConfigTests.cpp
@@ -95,6 +95,34 @@ TEST_F(ViewerConfigTest, ViewerConfig_Load_MissingFile_ReturnsFalse)
     EXPECT_FALSE(result);
 }
 
+TEST_F(ViewerConfigTest, ViewerConfig_Load_MissingFile_DoesNotModifyOutParam)
+{
+    // Arrange — caller pre-initialises to false (required by the contract:
+    // loadViewerConfig returns false without touching the out-param when the
+    // file is absent; the caller is responsible for resetting to the default).
+    bool auto_com_compute = false;
+
+    // Act
+    loadViewerConfig(test_folder, auto_com_compute);
+
+    // Assert — out-param unchanged; file-absent = keep caller's default (false)
+    EXPECT_FALSE(auto_com_compute);
+}
+
+TEST_F(ViewerConfigTest, ViewerConfig_Load_MissingFile_PreviousTrueValueLeaksWithoutPreInit)
+{
+    // Arrange — out-param set to true (simulates stale value from previous sim)
+    bool auto_com_compute = true;
+
+    // Act — no pre-initialisation to false before the call (the bug)
+    loadViewerConfig(test_folder, auto_com_compute);
+
+    // Assert — stale value persists because the function left the out-param alone.
+    // This test documents the leak; the caller MUST reset to false before calling
+    // loadViewerConfig when switching simulations.
+    EXPECT_TRUE(auto_com_compute); // stale — correct only after caller resets first
+}
+
 TEST_F(ViewerConfigTest, ViewerConfig_Load_UnknownKeys_AreIgnored)
 {
     // Arrange: manually write a file with unknown keys plus the known key

--- a/tests/mocks/MockCOMProvider.hpp
+++ b/tests/mocks/MockCOMProvider.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+/*
+ * MockCOMProvider.hpp
+ *
+ * Mock implementation of ICOMProvider for use in unit tests.
+ * Preset per-frame COM values with setCOM(); getCOM() returns true and
+ * writes the preset value on a hit, or returns false leaving out unchanged
+ * on a miss.
+ *
+ * Usage:
+ *   MockCOMProvider provider;
+ *   provider.setCOM(5, glm::vec3{1.0f, 2.0f, 3.0f});
+ *   glm::vec3 out;
+ *   bool ok = provider.getCOM(5, out);  // true; out == {1,2,3}
+ */
+
+#include <unordered_map>
+
+#include <glm/glm.hpp>
+
+#include "ICOMProvider.hpp"
+
+class MockCOMProvider : public ICOMProvider
+{
+  public:
+    /// Presets the COM value returned for @p frame.
+    void setCOM(long frame, const glm::vec3& value)
+    {
+        m_presets[frame] = value;
+    }
+
+    /// Returns true and writes the preset value into @p out if @p frame was
+    /// preset via setCOM(). Returns false and leaves @p out unchanged otherwise.
+    bool getCOM(long frame, glm::vec3& out) override
+    {
+        auto it = m_presets.find(frame);
+        if (it == m_presets.end()) {
+            return false;
+        }
+        out = it->second;
+        return true;
+    }
+
+  private:
+    std::unordered_map<long, glm::vec3> m_presets;
+};

--- a/tests/testing/SynchronousExecutor.hpp
+++ b/tests/testing/SynchronousExecutor.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include <functional>
+
+#include "IExecutor.hpp"
+
+/// SynchronousExecutor: runs enqueued tasks inline on the calling thread.
+/// Use in tests to avoid real thread scheduling and timing dependencies.
+class SynchronousExecutor : public IExecutor
+{
+  public:
+    void enqueue(std::function<void()> task) override
+    {
+        task();
+    }
+};

--- a/tests/testing/SynchronousExecutorTests.cpp
+++ b/tests/testing/SynchronousExecutorTests.cpp
@@ -1,0 +1,36 @@
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "IExecutor.hpp"
+#include "testing/SynchronousExecutor.hpp"
+
+TEST(SynchronousExecutorTests, SynchronousExecutor_Enqueue_RunsTaskImmediately)
+{
+    SynchronousExecutor executor;
+    bool flag = false;
+    executor.enqueue([&flag]() { flag = true; });
+    ASSERT_TRUE(flag);
+}
+
+TEST(SynchronousExecutorTests, SynchronousExecutor_EnqueueMultiple_RunsAllInOrder)
+{
+    SynchronousExecutor executor;
+    std::vector<int> order;
+    executor.enqueue([&order]() { order.push_back(1); });
+    executor.enqueue([&order]() { order.push_back(2); });
+    executor.enqueue([&order]() { order.push_back(3); });
+    ASSERT_EQ(order.size(), 3u);
+    ASSERT_EQ(order[0], 1);
+    ASSERT_EQ(order[1], 2);
+    ASSERT_EQ(order[2], 3);
+}
+
+TEST(SynchronousExecutorTests, SynchronousExecutor_DispatchesThroughBasePointer)
+{
+    SynchronousExecutor sync;
+    bool called = false;
+    IExecutor* base = &sync;
+    base->enqueue([&called]() { called = true; });
+    ASSERT_TRUE(called);
+}

--- a/tests/testing/TestFrameBuilder.hpp
+++ b/tests/testing/TestFrameBuilder.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <cassert>
 #include <fstream>
 #include <stdexcept>
 #include <string>
@@ -26,7 +25,9 @@ class TestFrameBuilder
     /// Velocities are written as zero.
     void addFrame(const std::vector<glm::vec4>& positions)
     {
-        assert(positions.size() == static_cast<std::size_t>(n_));
+        if (positions.size() != static_cast<std::size_t>(n_)) {
+            throw std::invalid_argument("TestFrameBuilder::addFrame: positions.size() != n_");
+        }
         for (const auto& p : positions) {
             append(p);
         }

--- a/tests/testing/TestFrameBuilder.hpp
+++ b/tests/testing/TestFrameBuilder.hpp
@@ -1,0 +1,79 @@
+#pragma once
+#include <cassert>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <glm/glm.hpp>
+
+/// Builds a synthetic PosAndVel binary buffer for testing.
+///
+/// Format matches readPosVelFile (settingsIO.hpp): each frame consists of
+/// N position glm::vec4 entries (with .w encoding the particle type) followed
+/// by N velocity glm::vec4 entries. Frames are laid out sequentially.
+///
+/// Particle type encoding (.w field):
+///   0 = Fe body1, 1 = Si body1, 2 = Fe body2, 3 = Si body2, 500 = default cube
+class TestFrameBuilder
+{
+  public:
+    explicit TestFrameBuilder(long n) : n_(n)
+    {
+    }
+
+    /// Appends one frame. positions.size() must equal n_.
+    /// Velocities are written as zero.
+    void addFrame(const std::vector<glm::vec4>& positions)
+    {
+        assert(positions.size() == static_cast<std::size_t>(n_));
+        for (const auto& p : positions) {
+            append(p);
+        }
+        const glm::vec4 zero{0.f, 0.f, 0.f, 0.f};
+        for (long i = 0; i < n_; ++i) {
+            append(zero);
+        }
+        ++frameCount_;
+    }
+
+    /// Writes the buffer to a temporary file and returns the file path.
+    std::string writeToTempFile(const std::string& suffix = ".bin") const
+    {
+        std::string path =
+            std::string("/tmp/TestFrameBuilder_") + std::to_string(reinterpret_cast<uintptr_t>(this)) + suffix;
+        std::ofstream f(path, std::ios::binary);
+        if (!f.is_open()) {
+            throw std::runtime_error("TestFrameBuilder: failed to open temp file: " + path);
+        }
+        f.write(reinterpret_cast<const char*>(buffer_.data()), static_cast<std::streamsize>(buffer_.size()));
+        if (f.fail()) {
+            throw std::runtime_error("TestFrameBuilder: write failed: " + path);
+        }
+        return path;
+    }
+
+    const std::vector<uint8_t>& buffer() const
+    {
+        return buffer_;
+    }
+    long frameCount() const
+    {
+        return frameCount_;
+    }
+    long n() const
+    {
+        return n_;
+    }
+
+  private:
+    long n_;
+    long frameCount_ = 0;
+    std::vector<uint8_t> buffer_;
+
+    void append(const glm::vec4& v)
+    {
+        const auto* bytes = reinterpret_cast<const uint8_t*>(&v);
+        buffer_.insert(buffer_.end(), bytes, bytes + sizeof(glm::vec4));
+    }
+};

--- a/tests/testing/TestFrameBuilderTests.cpp
+++ b/tests/testing/TestFrameBuilderTests.cpp
@@ -1,0 +1,104 @@
+#include <cstring>
+#include <fstream>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <glm/glm.hpp>
+
+#include "testing/TestFrameBuilder.hpp"
+
+TEST(TestFrameBuilderTests, TestFrameBuilder_AddFrame_BufferSizeMatchesFormat)
+{
+    const long n = 4;
+    TestFrameBuilder builder(n);
+    std::vector<glm::vec4> positions(n, glm::vec4(1.f, 2.f, 3.f, 0.f));
+    builder.addFrame(positions);
+    const std::size_t expected = static_cast<std::size_t>(n) * 2 * sizeof(glm::vec4);
+    ASSERT_EQ(builder.buffer().size(), expected);
+}
+
+TEST(TestFrameBuilderTests, TestFrameBuilder_AddFrame_PositionsStoredAtCorrectOffset)
+{
+    const long n = 3;
+    TestFrameBuilder builder(n);
+    glm::vec4 pos0(1.1f, 2.2f, 3.3f, 0.f);
+    std::vector<glm::vec4> positions = {pos0, glm::vec4(0.f), glm::vec4(0.f)};
+    builder.addFrame(positions);
+
+    glm::vec4 readBack;
+    std::memcpy(&readBack, builder.buffer().data(), sizeof(glm::vec4));
+    ASSERT_FLOAT_EQ(readBack.x, pos0.x);
+    ASSERT_FLOAT_EQ(readBack.y, pos0.y);
+    ASSERT_FLOAT_EQ(readBack.z, pos0.z);
+}
+
+TEST(TestFrameBuilderTests, TestFrameBuilder_AddFrame_VelocitiesAreZero)
+{
+    const long n = 2;
+    TestFrameBuilder builder(n);
+    std::vector<glm::vec4> positions(n, glm::vec4(5.f, 6.f, 7.f, 0.f));
+    builder.addFrame(positions);
+
+    // Velocity[0] starts at offset n * sizeof(glm::vec4)
+    const std::size_t velOffset = static_cast<std::size_t>(n) * sizeof(glm::vec4);
+    glm::vec4 vel0;
+    std::memcpy(&vel0, builder.buffer().data() + velOffset, sizeof(glm::vec4));
+    ASSERT_FLOAT_EQ(vel0.x, 0.f);
+    ASSERT_FLOAT_EQ(vel0.y, 0.f);
+    ASSERT_FLOAT_EQ(vel0.z, 0.f);
+    ASSERT_FLOAT_EQ(vel0.w, 0.f);
+}
+
+TEST(TestFrameBuilderTests, TestFrameBuilder_AddFrame_TypeEncodedInW)
+{
+    const long n = 1;
+    TestFrameBuilder builder(n);
+    glm::vec4 pos(1.f, 0.f, 0.f, 1.f); // .w = 1 => Si body1
+    builder.addFrame({pos});
+
+    glm::vec4 readBack;
+    std::memcpy(&readBack, builder.buffer().data(), sizeof(glm::vec4));
+    ASSERT_FLOAT_EQ(readBack.w, 1.f);
+}
+
+TEST(TestFrameBuilderTests, TestFrameBuilder_WriteToTempFile_FileReadableWithSameContent)
+{
+    const long n = 1;
+    TestFrameBuilder builder(n);
+    glm::vec4 pos(3.f, 4.f, 5.f, 0.f);
+    builder.addFrame({pos});
+
+    std::string path = builder.writeToTempFile(".bin");
+    std::ifstream f(path, std::ios::binary);
+    ASSERT_TRUE(f.is_open());
+
+    glm::vec4 readBack;
+    f.read(reinterpret_cast<char*>(&readBack), sizeof(glm::vec4));
+    ASSERT_FLOAT_EQ(readBack.x, pos.x);
+    ASSERT_FLOAT_EQ(readBack.y, pos.y);
+    ASSERT_FLOAT_EQ(readBack.z, pos.z);
+
+    // Cleanup
+    ASSERT_EQ(std::remove(path.c_str()), 0) << "Failed to remove temp file: " << path;
+}
+
+TEST(TestFrameBuilderTests, TestFrameBuilder_MultipleFrames_FrameCountCorrect)
+{
+    const long n = 3;
+    TestFrameBuilder builder(n);
+    std::vector<glm::vec4> positions(n, glm::vec4(0.f));
+    builder.addFrame(positions);
+    builder.addFrame(positions);
+    builder.addFrame(positions);
+
+    ASSERT_EQ(builder.frameCount(), 3L);
+    const std::size_t expected = 3u * static_cast<std::size_t>(n) * 2 * sizeof(glm::vec4);
+    ASSERT_EQ(builder.buffer().size(), expected);
+}
+
+TEST(TestFrameBuilderTests, TestFrameBuilder_AddFrame_WrongSize_Asserts)
+{
+    TestFrameBuilder builder(3);
+    ASSERT_DEATH(builder.addFrame({glm::vec4(0.f)}), "");
+}

--- a/tests/testing/TestFrameBuilderTests.cpp
+++ b/tests/testing/TestFrameBuilderTests.cpp
@@ -97,8 +97,8 @@ TEST(TestFrameBuilderTests, TestFrameBuilder_MultipleFrames_FrameCountCorrect)
     ASSERT_EQ(builder.buffer().size(), expected);
 }
 
-TEST(TestFrameBuilderTests, TestFrameBuilder_AddFrame_WrongSize_Asserts)
+TEST(TestFrameBuilderTests, TestFrameBuilder_AddFrame_WrongSize_Throws)
 {
     TestFrameBuilder builder(3);
-    ASSERT_DEATH(builder.addFrame({glm::vec4(0.f)}), "");
+    EXPECT_THROW(builder.addFrame({glm::vec4(0.f)}), std::invalid_argument);
 }


### PR DESCRIPTION
## What changed

Implements a background COM prefetch pipeline and a bounded LRU sliding-window frame cache, wired into `ViewerApp`. Adds 14 new source/header files, 24 new test files, and 393 total tests (391 passing; 2 pre-existing visual-regression baseline failures unrelated to this feature).

## Why

Closes #88. N-body simulations with many frames had two problems: (1) no mass-weighted centre-of-mass tracking when no COMFile was present, causing the camera to drift off the action; (2) each frame was read synchronously from disk on every render tick, causing stutter on large simulations. This feature adds async background prefetch for both particle frames and COM values, with a configurable memory-bounded LRU cache.

## Acceptance criteria

- [x] AC-1: When no COMFile is present, the viewer tracks the mass-weighted COM using a background compute pipeline (COMCache + COMCalculator)
- [x] AC-2: Playback remains smooth — frames are prefetched into a sliding-window LRU cache ahead of the current frame; synchronous fallback on miss ensures no freeze
- [x] AC-3: A "COM / Cache" top-level menu exposes an "Auto COM compute" checkbox; state is clearly indicated each frame
- [x] AC-4: Live cache status (frames cached, memory used) is displayed in the menu and updated every frame
- [x] AC-5: LRU eviction enforces the memory limit using floor-division; the cache never exceeds `floor(256 MB / frame_size)` frames
- [x] AC-6: When a COMFile is present, it is used exclusively — no regression to the computed path
- [x] AC-7: When auto-COM is disabled (default), the camera orbit centre is static; no background threads are started
- [x] AC-8: `kSimToDisplayScale = 0.25` (matching the vertex shader `transScale` uniform) is applied consistently to all COM values from both the compute path and the COMFile path

## Test plan

```bash
cmake --build build && ./build/tests/ParticleViewerTests
# Expected: 391 passed, 2 known pre-existing failures (visual regression baselines)
```

**Newly added test suites (373 tests across 14 suites):**
- `FrameCacheTest` (10) — LRU eviction, capacity enforcement, prefetch, duplicate-enqueue guard, cachedCount
- `COMCacheTest` (10) — hit/miss/prefetch/clear/count, empty-positions degenerate case
- `COMCalculatorTest` — mass-weighted COM formula correctness with known inputs
- `MassParamsTest` — struct construction and SettingsIO factory
- `ConstantsTest` — kSimToDisplayScale value
- `COMFileProviderTest` — ICOMProvider contract; COMFile present/absent paths
- `MockCOMProviderTest` — MockCOMProvider for injection testing
- `ReadPosBufferTest` — binary read correctness, frame clamping, isPlaying/errorCount mutation guards
- `StageTranslationsTest` — CPU-side particle staging
- `ViewerConfigTest` — viewer.cfg save/load round-trip
- `ViewerAppWiringTest` — structural wiring: field existence, default values
- `SynchronousExecutorTest`, `TestFrameBuilderTest` — test infrastructure

**Debug mode:** Press F3 to enable debug output. When active, `[COM]` and `[Cache]` lines print to stderr each frame showing frame index, cache hit/miss flags, COM values, and cached counts.

## Design decisions

| DDR | Decision | Rationale |
|-----|----------|-----------|
| DDR-1 | IExecutor injection (ThreadedExecutor prod / SynchronousExecutor test) | Keeps COMCache and FrameCache fully unit-testable without threading |
| DDR-2 | getCOM() returns nullopt on miss, enqueues background compute | No main-thread stall; camera keeps previous COM until result arrives (1-frame lag by design) |
| DDR-3 | FrameCache bounded by bytes (not frame count) | Memory limit is simulation-independent; floor division gives whole frames only |
| DDR-4 | Teardown order: executors drained before caches deleted | Background lambdas capture cache internals; destroying executor first joins the thread and guarantees tasks complete before cache memory is freed |
| DDR-5 | auto_com_compute defaults false; persisted to viewer.cfg per simulation folder | User opt-in prevents unexpected background threads on first launch; per-folder persistence respects different simulation setups |
| DDR-6 | COMFile path checked first, computed path never runs if COMFile is present | Zero regression risk for existing COMFile workflows |

**Three Amigos Signoff (Ceremony 5):** Business ✅ ACCEPTED · Developer ✅ ACCEPTED · Tester ✅ ACCEPTED