### PR TITLE
docs: add project-specific instantiations of genericized harness skills

### DIFF
--- a/.claude/agents/infrastructure-reviewer.md
+++ b/.claude/agents/infrastructure-reviewer.md
@@ -1,0 +1,121 @@
+---
+name: infrastructure-reviewer
+model: sonnet
+description: Use for per-file CI/CD, CMake build reproducibility, and Flatpak packaging compliance review for Particle Viewer.
+---
+
+# Infrastructure Reviewer Agent
+
+You are doing a per-file infrastructure review for Particle Viewer. Your ONLY job is to verify the file passes the pipeline safety, CMake build reproducibility, and Flatpak packaging checklists below. You are NOT a code quality reviewer -- do not comment on style, naming, or logic unrelated to infrastructure. See `docs/INFRASTRUCTURE_REVIEW.md` for the full reasoning behind each Particle Viewer-specific value; this checklist carries the items and the expected values, the doc carries the justification.
+
+## File under review
+{{FILE_PATH}}
+
+## Worktree Self-Check -- Run BEFORE starting
+
+```bash
+git -C {{WORKTREE_PATH}} rev-parse --show-toplevel
+```
+
+The output MUST match `{{WORKTREE_PATH}}`.
+- If it matches -> proceed.
+- If it does NOT match -> return immediately:
+  ```
+  STATUS: BLOCKED
+  Not running in the expected worktree. `git -C {{WORKTREE_PATH}} rev-parse --show-toplevel` returned [actual path],
+  expected {{WORKTREE_PATH}}.
+  ```
+
+## Review Protocol
+
+**Step 1 -- Full file read:** Read `{{FILE_PATH}}` in full. Do not skim.
+
+**Step 2 -- Run the full checklist** against the complete file content for every applicable section.
+
+**Step 3 -- Attribution:** Run `git diff $(git merge-base HEAD main) -- {{FILE_PATH}}` to get the diff. For each issue found, check whether the offending line appears in that output:
+- If YES -> **INTRODUCED** (blocker -- must fix before merge)
+- If NO -> **PRE-EXISTING** (note -- out of scope for this PR; log as separate cleanup task)
+
+Do not ask the caller to provide a diff. Derive it yourself.
+
+## Checklists
+
+Run every applicable section for the file type. Skip sections that do not apply (e.g., skip the packaging review for a `CMakeLists.txt` change). Run each section against the **full file**, not just changed lines.
+
+### 1. CI/CD Pipeline -- applies to `.github/workflows/*.yml`
+
+- [ ] No `git commit` or `git push` in any workflow step -- pipelines are read-only
+- [ ] All `permissions:` blocks are minimal -- read-only where possible; write only where explicitly justified
+- [ ] Artifacts uploaded with correct retention -- short for PRs (7 days), longer for releases (90 days)
+- [ ] No secrets hardcoded -- all sensitive values via `${{ secrets.X }}` only
+- [ ] Workflow triggers are intentional -- no unintended `workflow_run` chains
+- [ ] Matrix builds cover required platforms (Linux at minimum)
+- [ ] `actions/checkout` and other third-party actions pinned to a specific SHA, not a floating tag
+
+### 2. Reproducible Build Review -- applies to `CMakeLists.txt` (root and `tests/`)
+
+- [ ] Third-party dependencies declared via `FetchContent_Declare` in the root `CMakeLists.txt` are pinned to an immutable git tag: `imgui` at `v1.91.6`, `SDL3` at `release-3.2.6` (canonical SDL3 pin -- the two other SDL3 mentions in this file refer back to this value and move with it; `docs/INFRASTRUCTURE_REVIEW.md` is the source of truth), `googletest` at `release-1.12.1` -- never `main` or `master`
+- [ ] `find_package(SDL3)` fallback (system-installed SDL3, e.g. the Flatpak `sdl3` module) uses the same SDL3 tag as above, not an unpinned floating version -- see `docs/INFRASTRUCTURE_REVIEW.md`
+- [ ] Test target `ParticleViewerTests` (`tests/CMakeLists.txt`) remains a separate `add_executable` from the production target `Viewer` (`CMakeLists.txt`) -- neither links the other's object files
+- [ ] No hardcoded absolute paths -- source globs and dependency paths are built from `CMAKE_SOURCE_DIR`
+
+### 3. Sandboxed/Least-Privilege Packaging Review -- applies to `flatpak/org.particleviewer.ParticleViewer.yaml` and its sibling `.desktop`/`.metainfo.xml`/`.svg` files
+
+- [ ] Every `finish-args` capability is declared with an inline comment justifying it: `--device=all` (required for the NVIDIA proprietary driver path; disclosed as broader than graphics alone -- see `docs/INFRASTRUCTURE_REVIEW.md`), `--socket=x11`, `--socket=wayland`, `--share=ipc`, `--filesystem=home`, `--filesystem=host:ro`
+- [ ] Manifest declares only the capabilities the application actually needs -- no additional broad grants beyond the disclosed set above
+- [ ] Any new or widened permission grant is justified in writing via an inline comment in the manifest itself explaining why the minimum isn't sufficient -- a PR description alone is not verifiable evidence for this per-file review, which is scoped to reading `{{FILE_PATH}}` only
+- [ ] Third-party build modules are pinned to an immutable ref: `glm` to a release archive with a `sha256` digest, `sdl3` to the same SDL3 tag as above -- neither is a branch checkout
+- [ ] App ID `org.particleviewer.ParticleViewer` matches across the manifest, `.desktop`, and `.metainfo.xml` files
+- [ ] `runtime: org.freedesktop.Platform` and `sdk: org.freedesktop.Sdk` pinned to `runtime-version: '24.08'`, not a floating release
+- [ ] `--share=network` absent from finish-args -- Particle Viewer does not need network access
+
+## Rules
+
+- Quote the offending line before giving your finding -- do not paraphrase
+- Provide evidence for each failure: file:line
+- There is no SAFE verdict with open issues -- every checklist failure is ISSUES FOUND
+- Do NOT comment on logic, style, or naming unrelated to the checklists above
+- Do NOT suggest refactoring beyond identifying the specific checklist violation
+
+## Return format
+
+```
+## Infrastructure Review: [file]
+
+### Pipeline Safety (skip if not a workflow file)
+| Check | Result | Evidence |
+|-------|--------|----------|
+| No git commit/push in steps | [+]/[-] | ... |
+| Minimal permissions | [+]/[-] | ... |
+| Correct artifact retention | [+]/[-] | ... |
+| No hardcoded secrets | [+]/[-] | ... |
+| Correct triggers | [+]/[-] | ... |
+| Matrix builds cover required platforms | [+]/[-] | ... |
+| Third-party actions pinned | [+]/[-] | ... |
+
+### Build Reproducibility (skip if not CMakeLists.txt)
+| Check | Result | Evidence |
+|-------|--------|----------|
+| FetchContent deps pinned (imgui/SDL3/googletest) | [+]/[-] | ... |
+| find_package(SDL3) fallback still pinned | [+]/[-] | N/A if not applicable |
+| Test/production targets separated | [+]/[-] | ... |
+| No hardcoded paths | [+]/[-] | ... |
+
+### Packaging Compliance (skip if not a Flatpak manifest/sibling file)
+| Check | Result | Evidence |
+|-------|--------|----------|
+| finish-args capabilities declared and commented | [+]/[-] | ... |
+| Only needed capabilities declared | [+]/[-] | ... |
+| New/widened grants justified via in-manifest comment | [+]/[-] | ... |
+| Build modules pinned (glm sha256, sdl3 tag) | [+]/[-] | ... |
+| App ID consistent across manifest/desktop/metainfo | [+]/[-] | ... |
+| Runtime/SDK pinned to 24.08 | [+]/[-] | ... |
+| No --share=network | [+]/[-] | ... |
+
+### Critical Issues
+[Any [-] -- file:line quoted, and whether INTRODUCED or PRE-EXISTING]
+
+### Verdict: SAFE / ISSUES FOUND
+```
+
+ISSUES FOUND means the PR has at least one INTRODUCED issue that must be resolved before merge. PRE-EXISTING-only findings do not block the PR but must be logged as separate cleanup tasks.

--- a/docs/INFRASTRUCTURE_REVIEW.md
+++ b/docs/INFRASTRUCTURE_REVIEW.md
@@ -1,0 +1,47 @@
+---
+title: "Infrastructure Review Instantiation"
+description: "Particle Viewer's concrete build-reproducibility and packaging checklists, instantiating the story-to-ship infrastructure-review skill's generic rules for CMake and Flatpak."
+domain: cross-cutting
+subdomain: ""
+tags: [cross-cutting, process, review, build, packaging, flatpak, cmake]
+related:
+  - "VERIFICATION_COMMANDS.md"
+  - "flatpak/FLATPAK.md"
+  - "flatpak/flatpak-build.md"
+  - "flatpak/flatpak-gotchas.md"
+---
+
+# Particle-Viewer Infrastructure Review Instantiation
+
+The story-to-ship `infrastructure-review` skill defines tool-agnostic checklists for CI/CD pipelines, reproducible builds, and sandboxed/least-privilege packaging. This doc is the concrete instantiation of those checklists against Particle Viewer's actual build system (CMake) and packaging format (Flatpak) -- use it alongside the skill's generic checklist, not instead of it.
+
+## Reproducible Build Review (CMake)
+
+Applies to `CMakeLists.txt` (root and `tests/`):
+
+1. Third-party dependencies are declared via `FetchContent_Declare` in the root `CMakeLists.txt`: `imgui` (tag `v1.91.6`), `SDL3` (tag `release-3.2.6`), `googletest` (tag `release-1.12.1`). All three are pinned to an immutable git tag, never `main` or `master`.
+2. `find_package(SDL3)` is preferred over `FetchContent` when a system-installed SDL3 is available (e.g. the Flatpak `sdl3` module); this is a build-time selection, not an unpinned fallback -- the Flatpak module itself is still pinned to `release-3.2.6`.
+3. The test target `ParticleViewerTests` (`tests/CMakeLists.txt`) is a separate `add_executable` from the production target `Viewer` (`CMakeLists.txt`); neither links the other's object files.
+4. No hardcoded absolute paths -- source globs and dependency paths are built from `CMAKE_SOURCE_DIR`.
+
+## Sandboxed/Least-Privilege Packaging Review (Flatpak)
+
+Applies to `flatpak/org.particleviewer.ParticleViewer.yaml` and its sibling `.desktop`/`.metainfo.xml`/`.svg` files:
+
+1. `finish-args` declares only the capabilities the application needs, each with an inline comment justifying it:
+   - `--device=all` -- required for the NVIDIA proprietary driver path (`--device=dri` alone does not expose the NVIDIA userspace libraries). Disclosure: this grant is broader than graphics alone -- it exposes all host device nodes under `/dev` (input, USB, and other devices), not just the GPU nodes.
+   - `--socket=x11`, `--socket=wayland` -- display server access
+   - `--share=ipc` -- required alongside the X11/Wayland sockets
+   - `--filesystem=home` -- read-write access for writing `window.cfg`
+   - `--filesystem=host:ro` -- the ImGui file dialog browses the filesystem directly instead of using the FileChooser portal; this subsumes `xdg-documents` and `xdg-download`
+2. Third-party build modules declared in the manifest are pinned to an immutable ref: `glm` to a release archive with a `sha256` digest, `sdl3` to git tag `release-3.2.6` (the same tag the CMake `FetchContent` fallback uses in the Reproducible Build Review above) -- neither is a branch checkout. `glm` is pinned only here; it does not appear in `CMakeLists.txt` or `tests/CMakeLists.txt`.
+3. `--share=network` is absent -- Particle Viewer does not need network access, and none is granted.
+4. The app ID `org.particleviewer.ParticleViewer` matches the project's reverse-DNS naming convention and is consistent across the manifest, `.desktop`, and `.metainfo.xml` files.
+5. `runtime: org.freedesktop.Platform` and `sdk: org.freedesktop.Sdk` are pinned to `runtime-version: '24.08'`, not a floating release.
+
+## Related
+
+- [Verification Commands](VERIFICATION_COMMANDS.md) -- the build/test/format gate referenced by the Reproducible Build Review
+- [Flatpak Distribution Guide](flatpak/FLATPAK.md) -- navigation hub for Flatpak build, user, and troubleshooting docs
+- [Flatpak Build Guide](flatpak/flatpak-build.md) -- manifest configuration details for the checks above
+- [Flatpak CI/CD and Troubleshooting](flatpak/flatpak-gotchas.md) -- the permission grants and CI triggers referenced above

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -1,0 +1,345 @@
+---
+title: "Particle-Viewer Lessons Learned"
+description: "Particle-Viewer-specific war stories extracted from the development harness's lessons file, preserved verbatim."
+domain: cross-cutting
+subdomain: ""
+tags: [cross-cutting, process, lessons-learned, retrospective, opengl, sdl3, cmake, testing, imgui, glfw]
+related:
+  - "CODING_STANDARDS.md"
+  - "TESTING_STANDARDS.md"
+  - "visual-regression/camera-positioning-lessons-learned.md"
+---
+
+# Particle-Viewer Lessons Learned
+
+These entries were extracted from the development harness's (story-to-ship) self-evaluation skill
+reference file (`skills/self-evaluation/references/LESSONS_LEARNED_PATTERNS.md`), where they were
+mixed in with lessons general enough to apply to any project. These entries depend on Particle-Viewer
+specifics (OpenGL, SDL3, GLFW, ImGui, CMake, shader/particle code) and are kept here verbatim for
+war-story fidelity. A handful of these lessons also have a genericized distillation kept in the harness
+file; those are noted per entry below. Entries whose general lesson is already captured in a surviving
+harness skill (`testing`, `cpp-safety`, `cpp-patterns`, `workflow`) note that skill instead of repeating
+a distillation.
+
+---
+
+## Code Quality Lessons
+
+### Binary File I/O (PR #73)
+
+**Problem:** `getCOM()` opened binary data files with text mode (`"r"`), which on Windows translates `\r\n` bytes and corrupts binary reads.
+
+**Lesson:** Always open binary data files with `"rb"` mode for cross-platform correctness.
+
+**Added to:** `AGENTS.md` -> Error Handling section, `testing` skill -> Key Design Principles
+
+*Genericized distillation kept in the harness file: `skills/self-evaluation/references/LESSONS_LEARNED_PATTERNS.md` -> Code Quality Lessons -> "Open Binary Data Files in Binary Mode".*
+
+### Return By Const Reference (PR #73)
+
+**Problem:** `getProjection()` returned a `glm::mat4` by value, copying a 4x4 matrix every frame in the render loop.
+
+**Lesson:** Return large objects (matrices, vectors, structs) by `const&` from getters when the member is stored in the class.
+
+**Added to:** `AGENTS.md` -> Common Pitfalls
+
+*Genericized distillation kept in the harness file: `skills/self-evaluation/references/LESSONS_LEARNED_PATTERNS.md` -> Code Quality Lessons -> "Return Large Stored Objects by Const Reference".*
+
+### GLFW Key Bounds Check (PR #73)
+
+**Problem:** `keys_[key]` indexed without validation. GLFW can pass `GLFW_KEY_UNKNOWN` (-1), causing out-of-bounds access.
+
+**Lesson:** Bounds-check GLFW key callbacks -- `GLFW_KEY_UNKNOWN` is -1.
+
+**Added to:** `AGENTS.md` -> OpenGL Usage section
+
+---
+
+## Testing Lessons
+
+### Production Classes in Tests (PR #73)
+
+**Problem:** Visual regression test helper duplicated Particle's cube generation logic, creating a maintenance burden and false confidence.
+
+**Lesson:** Use production classes (e.g., `Particle`) directly in tests -- never duplicate production logic in test helpers.
+
+**Added to:** `testing` skill -> Key Design Principles, `TESTING_EXAMPLES.md` -> correct/incorrect patterns
+
+*Already generalized in the harness's surviving `testing` skill: `skills/testing/references/testing-anti-patterns.md` (Anti-Pattern 4, "use it -- for test data here, the production `Particle` class").*
+
+### Ensure Output Directories Exist (PR #72)
+
+**Problem:** Tests saved artifacts to `artifacts/` but only ensured `baselines/` existed. Silent write failures in CI.
+
+**Lesson:** Ensure all output directories exist in test `SetUp()`, and check `save()` return values.
+
+**Added to:** `testing` skill -> Self-Review Checklist
+
+*Genericized distillation kept in the harness file: `skills/self-evaluation/references/LESSONS_LEARNED_PATTERNS.md` -> Testing Lessons -> "Ensure Output Directories Exist Before Writing".*
+
+### Camera Positioning for Visual Tests (PR #71)
+
+**Problem:** Debug camera output was blindly copied as test camera coordinates, but debug shows interactive state, not ideal framing.
+
+**Lesson:** Extract viewing direction from debug output, but calculate distance based on desired viewport coverage. Formula: `distance = subject_size / (coverage_% * tan(FOV/2))`.
+
+**Added to:** `AGENTS.md` -> Visual Regression Tests section, `docs/visual-regression/camera-positioning-lessons-learned.md`
+
+---
+
+## Architecture Lessons
+
+### Group Related State Into Structs (PR #73)
+
+**Problem:** `ViewerApp` had 10+ flat member variables for window, rendering, recording state.
+
+**Lesson:** Group related member variables into Plain Old C++ Objects (POCOs)/structs (e.g., `WindowConfig`, `RenderResources`). Structs must provide their own defaults.
+
+**Added to:** `AGENTS.md` -> Data Organization, `testing` skill -> Key Design Principles
+
+*Already generalized in the harness's surviving `testing` skill: `skills/testing/SKILL.md` (BEFORE PROCEEDING item 9, "Group related configuration into structs/POCOs ... instead of flat variables").*
+
+### Headers Must Be Self-Contained (PR #70)
+
+**Problem:** `debugOverlay.hpp` used `std::cerr` without including `<iostream>`, relying on transitive includes.
+
+**Lesson:** Headers must include all their own dependencies. Don't rely on transitive includes from other headers.
+
+**Added to:** `AGENTS.md` -> Common Pitfalls
+
+*Already generalized in the harness's surviving `cpp-patterns` skill: `skills/cpp-patterns/SKILL.md` ("Every header must include all headers it directly uses -- no transitive include reliance", and the matching Red Flag / Rationalization Prevention rows).*
+
+### GL Resource Cleanup (PR #73)
+
+**Problem:** `cleanup()` only deleted FBO, leaking other GL objects (textures, renderbuffers, VAOs, VBOs).
+
+**Lesson:** Clean up ALL GL resources in destructors -- VAOs, VBOs, FBOs, RBOs, textures. Check for non-zero before deleting.
+
+**Added to:** `AGENTS.md` -> Memory Management
+
+*Already generalized in the harness's surviving `cpp-patterns` skill: `skills/cpp-patterns/SKILL.md` (Iron Law, and "Clean up ALL GL resources in destructors (VAOs, VBOs, FBOs, RBOs, textures)").*
+
+### GL_POINT_SIZE_RANGE Clamping (PR #81)
+
+**Problem:** Resolution independence test at 4K computed `gl_PointSize` of 366px, but hardware max was 256px. OpenGL silently clamped it, making the particle appear ~50% smaller. A loose test tolerance (0.01) masked the defect.
+
+**Lesson:** `gl_PointSize` is silently clamped by `GL_POINT_SIZE_RANGE` (256px on Mesa/llvmpipe). When testing resolution-independent scaling, choose camera distances that keep computed point sizes under this limit at all target resolutions. Use tolerances proportional to the values being compared -- an absolute tolerance larger than the expected value itself will mask real failures.
+
+**Added to:** `AGENTS.md` -> OpenGL Usage
+
+### Cross-Mesa Baseline Stability (PR #81)
+
+**Problem:** Adding `* (viewportHeight / REFERENCE_HEIGHT)` to the shader (where both equal 720.0, so `* 1.0`) caused a 1-pixel sprite-boundary difference on CI's Mesa version but not locally. The baseline comparison required 100% pixel match, so 1 pixel out of 921,600 failed the entire test.
+
+**Lesson:** Different Mesa/llvmpipe versions may compile the same shader differently, causing sprite-boundary rounding differences. Visual regression baselines MUST allow a small `MAX_DIFF_RATIO` (e.g., 0.01%) instead of requiring 100% pixel match. Always `ASSERT_TRUE(image.save(...))` artifact writes so debug images are not silently lost.
+
+**Added to:** `AGENTS.md` -> Test Issues
+
+---
+
+## Code Formatting and Verification Lessons
+
+### Silent Tool Output Does Not Mean Success (S5 code-quality audit)
+
+**Problem:** Session 5 ran `clang-format --dry-run -Werror src/shader.hpp` which had no output. Agent interpreted "no output = all files are clean" and skipped detailed verification. Later, an external formatting check failed, revealing that shader.hpp had three formatting issues: (1) exception caught by value instead of const reference, (2) unnecessary semicolons after function closing braces, (3) empty constructor using `{}` instead of `= default`.
+
+**Lesson:** Never rely on tool output silence to mean success. Always:
+1. After running `clang-format -i`, check `git diff` to see actual changes
+2. Visually spot-check modified files for common patterns (trailing semicolons after `}`, exception handling, multi-declarations, bracing)
+3. Only then run the dry-run verification
+
+**Added to:** `code-quality` skill -> Step 1 (Pre-Commit Checklist) + new Step 3 (Human-Reviewable Formatting Patterns table)
+
+*Genericized distillation kept in the harness file: `skills/self-evaluation/references/LESSONS_LEARNED_PATTERNS.md` -> Code Formatting and Verification Lessons -> "Silent Tool Output Is Not Proof of Success".*
+
+### FetchContent for Libraries Without CMakeLists.txt (PR #79, updated PR #82)
+
+**Problem:** ImGui doesn't ship a CMakeLists.txt, so `FetchContent_MakeAvailable()` tries to call `add_subdirectory()` and fails. Using `FetchContent_Populate()` works but is deprecated in CMake 3.31+.
+
+**Lesson:** Use `FetchContent_Declare()` with `SOURCE_SUBDIR` set to a non-existent path, then call `FetchContent_MakeAvailable()`. This downloads the source without attempting `add_subdirectory()`, and avoids the `FetchContent_Populate()` deprecation warning. Then add the source files manually to your target.
+
+**Added to:** `AGENTS.md` -> ImGui Integration
+
+### GLFW Callback Chaining Order (PR #79)
+
+**Problem:** ImGui's GLFW backend saves and chains to existing callbacks when `install_callbacks=true`. If ImGui is initialized before ViewerApp sets its callbacks, the chain is broken.
+
+**Lesson:** Set application GLFW callbacks (e.g., `glfwSetKeyCallback`) **before** calling `ImGui_ImplGlfw_InitForOpenGL(window, true)`. ImGui saves the current callbacks and chains to them, ensuring both ImGui and the application receive input events.
+
+**Added to:** `AGENTS.md` -> ImGui Integration
+
+### ImGui Renders to Default Framebuffer (PR #79)
+
+**Problem:** Needed to ensure ImGui menus don't appear in FBO-based screenshots and frame recordings.
+
+**Lesson:** ImGui renders to the default framebuffer after the FBO blit pass. Since recording reads pixels from the offscreen FBO (before the blit), ImGui content is naturally excluded. This is an architectural advantage of the FBO pipeline -- no special handling needed.
+
+**Added to:** `AGENTS.md` -> ImGui Integration
+
+### Debug Overlay Must Offset for Menu Bar (PR #79)
+
+**Problem:** Debug overlay positioned at y=5 was hidden behind the ImGui menu bar (~25px high). The first line (including FPS counter) was not visible.
+
+**Lesson:** Use ImGui windows instead of raw GL overlays -- `ImGui::GetFrameHeight()` gives the actual menu bar height for dynamic positioning. This avoids hard-coded offsets that break with DPI/font scaling changes.
+
+**Added to:** `AGENTS.md` -> ImGui Integration
+
+---
+
+## Process Lessons
+
+### Fix Issues at the Source, Not in CI (PR #82)
+
+**Problem:** Visual regression test artifacts used names like `single_particle_720p.png` that didn't match the CI workflow regex `_baseline|_current|_diff`. The quick fix was to expand the regex; the correct fix was to rename artifacts at the source.
+
+**Lesson:** When CI reports show incorrect categorization (e.g., "unknown" type for test images), fix the naming convention in the test code -- not the CI regex. CI patterns MUST enforce conventions, not accommodate deviations.
+
+**Added to:** Self-evaluation skill (harness file, at the time this lesson was captured)
+
+*Genericized distillation kept in the harness file: `skills/self-evaluation/references/LESSONS_LEARNED_PATTERNS.md` -> Process Lessons -> "Fix Naming/Categorization Issues at the Source, Not in the Checker".*
+
+### Always Upload Current Images (PR #64)
+
+**Problem:** Visual regression CI only uploaded artifacts on failure, making it hard to review passing tests.
+
+**Lesson:** Always save and upload current rendered images, even when tests pass. Use `if: always()` on upload steps.
+
+**Added to:** `workflow` skill -> Artifact Upload Pattern
+
+*Already generalized in the harness's surviving `workflow` skill: `skills/workflow/SKILL.md` ("`if: always()` on artifact upload and PR comment steps where needed") and `skills/workflow/references/WORKFLOW_EXAMPLES.md`.*
+
+---
+
+## SDL3 Migration Lessons
+
+### SDL3 MSAA Strict Enforcement (SDL3 migration PR)
+
+**Problem:** `SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 4)` caused `SDL_CreateWindow` to return NULL in Mesa/Xvfb environments. GLFW silently fell back to no MSAA; SDL3 strictly refuses to create the window if the requested visual isn't available.
+
+**Lesson:** Always add a fallback retry for MSAA: attempt creation with 4x MSAA first; if that returns NULL, reset the attribute to 0 and retry. This ensures headless/CI tests can run on software renderers.
+
+**Added to:** `AGENTS.md` -> OpenGL Usage section
+
+### FetchContent Ordering With Full-CMake Dependencies (SDL3 migration PR)
+
+**Problem:** Adding SDL3 via `FetchContent_MakeAvailable(SDL3)` (which has its own `CMakeLists.txt`) corrupted CMake 3.31's internal FetchContent state, causing subsequent `FetchContent_MakeAvailable(googletest)` to fail with "Internal error: SUBBUILD_DIR not set".
+
+**Lesson:** When mixing FetchContent dependencies, make all lightweight/header-only deps (ImGui) and all non-subdirectory deps (GoogleTest) available **before** a full-CMakeLists dep (SDL3). Declare all deps at the top, then call `FetchContent_MakeAvailable` in a safe order.
+
+**Added to:** `AGENTS.md` -> ImGui Integration / Architecture section
+
+### Search All Files During Backend Migration (SDL3 migration PR)
+
+**Problem:** During GLFW->SDL3 migration, `src/ui/imgui_menu.cpp` still included `<GLFW/glfw3.h>` and called `glfwGetPrimaryMonitor()`. Initial grep missed it because the search targeted `viewer_app*`, `camera*`, and `main.cpp` but not the UI layer.
+
+**Lesson:** When migrating a windowing/graphics backend, search ALL source files (`find src -name "*.cpp" -o -name "*.hpp" | xargs grep OLDLIBNAME`) rather than targeting specific files by name. The old API may appear in unexpected locations (monitor queries in menu code, etc.).
+
+**Added to:** `AGENTS.md` -> Common Pitfalls (as a Build Issues entry)
+
+### SDL3 Subsystem Flag Missing Causes Silent Failure (gamepad PR)
+
+**Problem:** Gamepad input was implemented and merged but never worked on any device (Steam Deck, Bluetooth, USB). `SDL_Init(SDL_INIT_VIDEO)` was never updated when the gamepad subsystem was added. Without `SDL_INIT_GAMEPAD`, `SDL_GetGamepads()` returns empty, `SDL_EVENT_GAMEPAD_ADDED` is never fired, and all controllers are invisible -- no error, no warning.
+
+**Lesson:** Every SDL3 subsystem needs its `SDL_INIT_*` flag in the `SDL_Init` call in `SDL3Context.cpp`. Adding a new SDL3 feature (gamepad, audio, haptic) **always** requires updating this call. Missing a flag is a silent failure -- SDL3 does not warn that the subsystem was never started.
+
+**Added to:** `code-quality` skill -> OpenGL Usage section
+
+### SDL3 `*ForID` Functions Avoid Unnecessary Device Open/Close (gamepad PR)
+
+**Problem:** In `addXInputMapping()`, the GUID was retrieved by calling `SDL_OpenJoystick()`, reading the GUID with `SDL_GetJoystickGUID()`, then calling `SDL_CloseJoystick()`. SDL3 provides `SDL_GetJoystickGUIDForID(instance_id)` specifically to avoid this open/close dance.
+
+**Lesson:** When querying joystick properties by instance ID, always check for a `SDL_Get*ForID()` variant first: `SDL_GetJoystickGUIDForID`, `SDL_GetJoystickTypeForID`, `SDL_GetJoystickVendorForID`, `SDL_GetJoystickProductForID`, etc. Opening a device to read a property and immediately closing it wastes a file handle and SDL3 reference counts unnecessarily.
+
+**Added to:** `code-quality` skill -> OpenGL Usage section
+
+### SDL3 Joystick Type Is Distro-Dependent (gamepad PR)
+
+**Problem:** `SDL_GetJoystickTypeForID()` returns `SDL_JOYSTICK_TYPE_GAMEPAD` on SteamOS for the 8BitDo 2.4GHz dongle, but `SDL_JOYSTICK_TYPE_UNKNOWN` on OpenSuse Tumbleweed (and presumably other non-SteamOS distros). The SDL3 joystick type is derived from udev properties that Valve sets via custom rules on SteamOS but are absent on stock Linux. The fallback that only checked `SDL_JOYSTICK_TYPE_GAMEPAD` silently skipped the device on OpenSuse.
+
+**Lesson:** Never rely on `SDL_GetJoystickTypeForID() == SDL_JOYSTICK_TYPE_GAMEPAD` alone for cross-distro gamepad detection. Always pair it with a capability-based fallback for `SDL_JOYSTICK_TYPE_UNKNOWN` devices: open the joystick briefly, check `SDL_GetNumJoystickAxes() >= 4 && SDL_GetNumJoystickButtons() >= 6`, close it, and treat as a gamepad candidate if the heuristic passes.
+
+**Added to:** `code-quality` skill -> OpenGL Usage section
+
+### Gamepad Hold-Button -> KeyReader Routing Causes Repeated Single-Press Events (gamepad PR)
+
+**Problem:** To mirror Shift-key speed boost on the B gamepad button, initial implementation called `cam_->KeyReader(SDL_SCANCODE_LSHIFT, held)` every frame. `KeyReader` has a `if (is_pressed)` single-press dispatch block -- calling it every frame with `is_pressed=true` would fire any single-press handlers for that scancode on every frame, not just on the initial press.
+
+**Lesson:** For gamepad hold-buttons that mirror keyboard *held* keys (e.g. B -> Shift for speed boost), **never** route through `Camera::KeyReader()`. Instead, add a dedicated thin method that sets only the key state directly (e.g. `Camera::setSpeedBoost(bool active) { keys[SDL_SCANCODE_LSHIFT] = active; }`). Call it every frame with the current hold state -- it's safe because it bypasses the single-press dispatch entirely.
+
+**Added to:** `code-quality` skill -> OpenGL Usage section
+
+### Don't Remove Camera API Methods When Only the Call Site Changes (gamepad PR)
+
+**Problem:** When L3/R3 sphere distance controls were removed at user request, `isRenderingSphere()` was also deleted from `Camera` because `viewer_app.cpp` was the only caller. One session later, the user re-requested L3/R3, requiring `isRenderingSphere()` to be restored -- unnecessary rework.
+
+**Lesson:** When removing a call site in `viewer_app.cpp` (e.g. a gamepad feature), **do not also delete the supporting `Camera` public method**. The Camera API is stable; call sites in `viewer_app` are volatile (controlled by user preference). Only remove a Camera method if it is architecturally incorrect or duplicates something, not merely because it has no callers at the moment.
+
+**Added to:** `code-quality` skill -> Step 7: Adding a Feature / Fixing a Bug
+
+*Genericized distillation kept in the harness file: `skills/self-evaluation/references/LESSONS_LEARNED_PATTERNS.md` -> Process Lessons -> "Do Not Delete a Stable API Method When Only Its Caller Is Removed".*
+
+### EXPECT_EQ Over EXPECT_LE for Deterministic Counts (PR #112)
+
+**Problem:** `FrameCache` pending-cap test used `EXPECT_LE(callCount, window)`. The count is deterministically equal to `window` -- using LE hid the fact that a regression (under-enqueue) would still pass.
+
+**Lesson:** Use `EXPECT_EQ` when the value is deterministic. `EXPECT_LE`/`EXPECT_GE` are for inherently non-deterministic values (timing, OS scheduling). An overly lenient bound masks regressions.
+
+**Added to:** `testing` skill -> `TESTING_EXAMPLES.md` -> Incorrect Examples
+
+### Binary File Tests: Record Count Must Cover Target Frame (PR #112)
+
+**Problem:** `COMFileProvider_FrameIndexMismatch_ReturnsFalse` was written with a single-record file and a request for frame 1. `fseek` to frame 1 went past EOF, so `fread` returned 0 (truncation), exercising the wrong branch.
+
+**Lesson:** When writing a binary file test that seeks to frame N, write at least N+1 records so `fseek` lands within the file and `fread` actually reads the target record. A single-record file will always produce a truncation result for any frame > 0.
+
+**Added to:** `testing` skill -> `TESTING_EXAMPLES.md` -> Incorrect Examples
+
+*Genericized distillation kept in the harness file: `skills/self-evaluation/references/LESSONS_LEARNED_PATTERNS.md` -> Testing Lessons -> "Binary Seek Tests Need N+1 Records to Reach the Target Offset".*
+
+### Full Docstring Rewrite Required When void->bool (PR #112)
+
+**Problem:** After changing `getCOM()` from void to bool, the docstring was patched to mention the return value, but the first sentence still said "caller must call checkCOM() first" while a later sentence said "no extra checkCOM round-trip". The two sentences contradicted each other.
+
+**Lesson:** When changing a function's calling contract (especially void->bool), rewrite the *entire* docstring -- don't patch it. The new contract (all false-return cases, what the caller need not do) renders the old docstring structurally incorrect and patching a structurally wrong docstring still leaves it wrong.
+
+**Added to:** Self-evaluation skill (harness file, at the time this lesson was captured)
+
+### Test Names Must Describe Behavior Proven, Not Return Value (PR #112, round 2)
+
+**Problem:** `GetCOM_ValidFile_Frame1_ReturnsTrue` described the return value, not what property was being verified. Code review renamed it to `GetCOM_ValidFile_Frame1_SeekIsAbsolute` -- the test was specifically checking that `SEEK_SET` (absolute seek) was used.
+
+**Lesson:** The `_ExpectedResult` segment of `UnitName_StateUnderTest_ExpectedResult` must encode the *invariant or property proven*, not just the return value. `_SeekIsAbsolute` answers "what holds?"; `_ReturnsTrue` answers "what came back?" -- the latter masks what the test is actually verifying.
+
+**Added to:** `testing` skill -> Naming Convention section
+
+*Already generalized in the harness's surviving `testing` skill: `skills/testing/SKILL.md` (Naming Convention section, "`_ExpectedResult` must describe the behavior or invariant proven -- not the return value").*
+
+### Failure-Path Tests Must Assert Output Parameters Are Unchanged (PR #112, round 2)
+
+**Problem:** Failure-path tests for `getCOM()` only called `EXPECT_FALSE(...)` without asserting that the output parameter `value` was unchanged. A regression that modified `value` even on failure would pass all tests.
+
+**Lesson:** For any function returning bool/error-code: in failure-path tests, always assert output parameters remain at their initial value (`EXPECT_EQ(outValue, glm::vec3(0.f))` after `EXPECT_FALSE(...)`). Initialize output params to a known value in Arrange so the Assert is meaningful.
+
+**Added to:** `testing` skill -> Self-Review Checklist
+
+*Already generalized in the harness's surviving `testing` skill: `skills/testing/SKILL.md` (BEFORE PROCEEDING item 13, "failure-path tests assert output parameters are unchanged").*
+
+### Two-Step Factory Method Exception Safety (PR #112, round 2)
+
+**Problem:** `createCOMInfrastructure()` allocated `com_executor_` then `com_cache_`. If `COMCache` constructor threw, `com_executor_` leaked because the destructor was never called (method-level allocation, not a constructor).
+
+**Lesson:** When a factory method (not a constructor) sequentially allocates two raw pointers, wrap the second `new` in try-catch: delete and null the first pointer before rethrowing. This is the raw-pointer equivalent of scope-bound guards when `unique_ptr` is impractical.
+
+**Added to:** `cpp-safety` skill -> Constructor Rule section
+
+*Already generalized in the harness's surviving `cpp-safety` skill: `skills/cpp-safety/SKILL.md` (Constructor Rule section, matching code example).*
+
+### Expose Derived Quantities on the Interface to Prevent DRY Violations (PR #112, round 2)
+
+**Problem:** `viewer_app.cpp` computed `bytes_used = frame_cache_->capacity() * particles_per_frame * sizeof(glm::vec4)` -- duplicating `FrameCache`'s internal `frame_size_bytes` formula. If per-particle data layout changed, the call site would silently produce wrong values.
+
+**Lesson:** When a call site derives a value from an interface (counts, sizes, compound formulas), add the derived quantity as a virtual method on the interface. The concrete class is the single source of truth; callers receive the value without re-deriving it. Signal: "if the formula changes, I need to update it in N places."
+
+**Added to:** `cpp-patterns` skill -> DRY section
+
+*Already generalized in the harness's surviving `cpp-patterns` skill: `skills/cpp-patterns/SKILL.md` (DRY section, "Interface exposure signal").*


### PR DESCRIPTION
Phase B companion to the story-to-ship genericization branch: as each harness skill sheds its Particle-Viewer specifics, the concrete PV material lands here as project docs. Opened as a draft at phase start; updated as todos land. Merge order: this PR merges before the story-to-ship one (content is added here before it is removed there).

First doc: docs/INFRASTRUCTURE_REVIEW.md -- the PV instantiation of the reproducible-build and least-privilege packaging review checklists, with all pins and finish-args verified against CMakeLists.txt and the Flatpak manifest.

Generated with [Claude Code](https://claude.com/claude-code)