### PR TITLE
docs: import story examples and development workflow from harness (batch 2)

### DIFF
--- a/docs/DEVELOPMENT_WORKFLOW.md
+++ b/docs/DEVELOPMENT_WORKFLOW.md
@@ -1,0 +1,37 @@
+---
+title: "Development Workflow"
+description: "Feature-addition, feature-removal, and bug-fix workflow patterns for Particle-Viewer, imported from the development harness."
+domain: cross-cutting
+subdomain: ""
+tags: [cross-cutting, process, workflow, testing]
+related:
+  - "TESTING_STANDARDS.md"
+  - "CODING_STANDARDS.md"
+---
+
+# Development Workflow
+
+These workflow patterns were extracted from the development harness's (story-to-ship) `code-quality` skill reference file (`skills/code-quality/references/oop/cpp/cpp-toolchain.md`) and are kept here verbatim, since they depend on Particle-Viewer specifics (`Camera`, `viewer_app.cpp`, gamepad input, `isRenderingSphere()`) that do not belong in a project-neutral skill reference.
+
+## New Feature Workflow
+1. **Scan the class interface** -- before writing integration code that calls methods on an existing class, verify which members are public/private. Classes like `Camera` have a mix; don't assume public.
+2. Make code changes following naming conventions
+3. Add unit tests in `tests/core/` (see `docs/TESTING_STANDARDS.md`)
+4. Run `clang-format -i` on ALL changed files
+5. Build and verify tests pass
+6. Commit: `feat: description`
+
+## Removing Features / User-Requested Changes
+When removing a gamepad feature or call site from `viewer_app.cpp` at user request, **do not also delete the supporting `Camera` public method**. The Camera API is stable across sessions; call sites in `viewer_app` change frequently with user preferences. Removing `isRenderingSphere()` when L3/R3 was dropped meant restoring it when L3/R3 came back one session later. Only remove a Camera method if it is architecturally wrong, not merely unused at the current moment.
+
+## Bug Fix Workflow
+1. Write a failing test that reproduces the bug
+2. Fix the code
+3. Verify test passes, run full suite
+4. Run `clang-format -i` on changed files
+5. Commit: `fix: description`
+
+## Related
+
+- [Testing Standards](TESTING_STANDARDS.md) -- AAA pattern, naming conventions, mocking, and coverage expectations for all tests
+- [Coding Standards](CODING_STANDARDS.md) -- formatting and naming conventions

--- a/docs/STORY_EXAMPLES.md
+++ b/docs/STORY_EXAMPLES.md
@@ -1,0 +1,124 @@
+---
+title: "Story Examples"
+description: "Worked story-writing examples for Particle Viewer -- acceptance criteria, technical notes, and subtask breakdowns for calibrating new stories."
+domain: cross-cutting
+subdomain: ""
+tags: [cross-cutting, planning, stories, templates]
+related:
+  - "ESTIMATION_EXAMPLES.md"
+  - "PROJECT_CONTEXT.md"
+---
+
+# Particle-Viewer Story Examples
+
+Worked story examples imported from the development harness, kept for calibrating how new stories are written (acceptance criteria style, technical-notes detail, subtask breakdown). These are illustrative, not current-state documentation: the refactoring example below names `FramebufferManager`/`WindowManager` as a target design, but the delivered shape (per [Estimation Examples](ESTIMATION_EXAMPLES.md)) is a `ViewerApp` class plus plain data structs.
+
+---
+
+## Acceptance Criteria: Framebuffer Capture
+
+Example of Given/When/Then acceptance criteria for a feature story:
+
+- [ ] **Given** an OpenGL context with a bound framebuffer, **When** `captureFrame()` is called, **Then** a PPM file is written to disk within 16ms
+- [ ] Image data is captured with correct RGBA format and proper vertical flip (OpenGL origin compensation)
+- [ ] Handles edge cases: no active framebuffer, resolution changes mid-capture
+- [ ] File I/O succeeds with no memory leaks (validated with Valgrind)
+
+---
+
+## Technical Notes: Refactoring Example
+
+Example Technical Notes section for a refactoring story that extracts global state into owning classes:
+
+**Current State (Before):**
+- Global variables: `framebuffer`, `window`, `particle_set`
+- Issue: Hard to test in isolation, can't run tests in parallel
+
+**Target State (After):**
+- `FramebufferManager` class encapsulating framebuffer state
+- `WindowManager` class managing window lifecycle
+- All state passed as constructor dependencies
+
+**Files to Create/Modify:**
+- `src/graphics/FramebufferManager.hpp` (new)
+- `src/graphics/FramebufferManager.cpp` (new)
+- `src/main.cpp` (refactored to use new manager)
+
+**Definition of Done:**
+- [ ] Old code deleted (no dead code left behind)
+- [ ] All tests pass on CI
+- [ ] Code review completed
+- [ ] No performance regression (benchmark before/after)
+- [ ] Refactoring checklist applied (remove duplication, improve names, etc.)
+
+---
+
+## Subtask Breakdown Example
+
+Example of breaking a larger story into estimated, dependency-ordered subtasks:
+
+**Parent Story:** Create Framebuffer Capture Utility
+
+### Subtask 1: Design FramebufferCapture Class
+- [ ] Define public API (methods, error codes)
+- [ ] Document memory ownership (who deletes buffers?)
+- [ ] Sketch architecture: OpenGL initialization, capture, conversion
+
+**Estimate:** S (2-3 hours)
+
+---
+
+### Subtask 2: Implement Frame Capture
+- [ ] Write FramebufferCapture::captureFrame() method
+- [ ] Test with manual OpenGL context in isolated test
+- [ ] Handle edge cases (no framebuffer bound, resolution mismatch)
+
+**Estimate:** M (4-6 hours)
+**Depends on:** Subtask 1
+
+---
+
+### Subtask 3: Implement PPM File Writing
+- [ ] Write pixel data to PPM format
+- [ ] Ensure vertical flip is correct
+- [ ] Test with ImageMagick `display` to verify output
+
+**Estimate:** S (2-3 hours)
+**Depends on:** Subtask 2
+
+---
+
+### Subtask 4: Unit Tests & Integration
+- [ ] Write GoogleTest tests for FramebufferCapture
+- [ ] Mock OpenGL calls
+- [ ] Test in headless mode with Xvfb
+
+**Estimate:** M (4-6 hours)
+**Depends on:** Subtasks 2-3
+
+---
+
+## BDD-Style Acceptance Criteria
+
+Example of a Given/When/Then acceptance criterion parameterized with a specific resolution:
+
+- [ ] **Given** a valid OpenGL context, **When** captureFrame() is called with resolution 1920x1080, **Then** a 1920x1080 PPM file is created within 16ms
+
+---
+
+## Metric-Based Acceptance Criteria
+
+Example of acceptance criteria phrased as measurable metrics rather than Given/When/Then:
+
+- [ ] Frame capture latency <=16ms (60 FPS budget)
+- [ ] Memory overhead <=50MB per capture
+- [ ] Zero memory leaks (Valgrind report)
+
+---
+
+## File/Component-Specific Acceptance Criteria
+
+Example of acceptance criteria that pin down exactly which files carry the tests and the implementation, including the current-state to target-state renaming convention:
+
+- [ ] Tests in `tests/core/FramebufferCaptureTests.cpp` (or target-state: `tests/graphics/FramebufferCaptureTests.cpp`)
+- [ ] Implementation in `src/FramebufferCapture.{hpp,cpp}` (or target-state: `src/graphics/framebuffer_capture.{hpp,cpp}`)


### PR DESCRIPTION
Second import batch from the development harness (follow-on to #133/#134), paired with story-to-ship draft PR #61 which removes/neutralizes the source copies. Merge this PV side first (add-before-remove).

Two commits:

1. `docs: import development workflow patterns from development harness` (608ebed) -- RECOVERED COMMIT, please note: this exact commit (as 30959e3) was reviewed, pushed to `feat/import-harness-b`, and intended for #134, but #134's squash merge snapshotted the branch before this push landed, so `docs/DEVELOPMENT_WORKFLOW.md` never reached main (the #134 squash contains 3 files; the branch tip had 4). Cherry-picked here unchanged. It adds `docs/DEVELOPMENT_WORKFLOW.md` (37 lines): New Feature / Removing Features / Bug Fix workflow sections with frontmatter matching docs/ siblings.

2. `docs: import story worked examples from development harness` (ea09076) -- adds `docs/STORY_EXAMPLES.md` (124 lines): the Particle-Viewer-flavored worked story examples leaving the harness's story-template reference (Framebuffer Capture acceptance criteria, FramebufferManager refactoring technical notes, subtask breakdown, and three AC-variant snippets). Conservation was reviewed block-by-block against the source; the intro flags that the refactoring example's target design is historical (delivered shape per ESTIMATION_EXAMPLES.md is `ViewerApp` + data structs). The "Current Workflow Structure" section from the harness's workflow examples was adjudicated already-covered by `docs/testing/visual-regression-ci.md:41-58` -- no duplicate added.

Review pipeline per unit: implementer -> Stage 1 spec/conservation review -> Stage 2 quality review. Story-examples unit had one fix round (two omitted snippets restored byte-exact; Stage 1 delta PASS, Stage 2 APPROVE WITH NITS -- nits are cosmetic: heading parallelism, frontmatter description scope).

`docs/INDEX.md` rows for both files are deferred to the batched index update (which also owes rows for INFRASTRUCTURE_REVIEW.md and lessons-learned.md from #134).

ASCII sweeps clean on both files (exit 1).

Generated with [Claude Code](https://claude.com/claude-code)
