### PR TITLE
docs: describe skill provisioning sources and index imported docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ Particle-Viewer is a C++ OpenGL-based viewer for N-Body simulations -- viewing 3
 
 ## Skills Directory
 
-Skills are provided by the **`jpegthedev/story-to-ship`** plugin marketplace. Install: `/plugin marketplace add jpegthedev/story-to-ship` then `/plugin install story-to-ship@story-to-ship`. Installed skills land in `.claude/skills/`; agents in `.claude/agents/`.
+Most skills are provided by the **`jpegthedev/story-to-ship`** plugin marketplace. Install: `/plugin marketplace add jpegthedev/story-to-ship` then `/plugin install story-to-ship@story-to-ship`. Installed skills land in `.claude/skills/`; agents in `.claude/agents/`. This repo also commits its own project-specific skills (`build`, `flatpak`) and agent templates (`architecture-reviewer.md`, `infrastructure-reviewer.md`) at those same paths, so plugin-installed and repo-committed sources coexist there.
 
 Each skill owns one domain. Read the skill before working in that domain. **Never duplicate skill content in this file.**
 
@@ -144,7 +144,7 @@ Skills are organized into **DDD bounded contexts**. Sub-domain skills (e.g., `vi
 
 ### Agent Prompt Templates
 
-Reusable agent prompts live in `.claude/agents/`. Use these when dispatching subagents via the `task` tool:
+Reusable agent prompts live in `.claude/agents/`. `architecture-reviewer.md` and `infrastructure-reviewer.md` are committed in this repo; the rest are plugin-installed. Use these when dispatching subagents via the `task` tool:
 
 | Template | Use when |
 |----------|----------|
@@ -204,8 +204,10 @@ tests/
 
 docs/                     # Human-readable guides and standards
 .claude/settings.json     # Plugin declaration: jpegthedev/story-to-ship (extraKnownMarketplaces + enabledPlugins)
-                          # .claude/skills/, .claude/agents/, .claude/hooks/ are NOT in the repo --
-                          # they are installed at session start by the story-to-ship plugin
+                          # .claude/hooks/ and most skills/agents are installed at session start
+                          # by the story-to-ship plugin, not committed here. .claude/skills/build/,
+                          # .claude/skills/flatpak/, and the architecture-reviewer.md /
+                          # infrastructure-reviewer.md agent templates ARE committed in this repo
 scratch/                  # Session workspace for exploratory/intermediate files
                           # Use for: large text dumps, intermediate analysis, theory-testing artifacts
                           # DO NOT commit scratch/ contents -- it is .gitignored

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -72,6 +72,10 @@ Catalog of every documentation file directly under `docs/`. Integration-test and
 | `ESTIMATION_EXAMPLES.md` | Validated real-world effort estimates from completed stories, for calibrating new estimates against actual outcomes. |
 | `VERIFICATION_COMMANDS.md` | Build, test, and format commands to run before every commit. |
 | `DEBUGGING.md` | Debug commands for build, test filtering, visual regression diffs, and CI reproduction. |
+| `DEVELOPMENT_WORKFLOW.md` | Feature-addition, feature-removal, and bug-fix workflow checklists for Particle-Viewer. |
+| `STORY_EXAMPLES.md` | Worked story-writing examples -- Given/When/Then and metric-based acceptance criteria, a refactoring technical-notes template, and a dependency-ordered subtask breakdown. |
+| `lessons-learned.md` | Particle-Viewer-specific war stories on OpenGL, SDL3, GLFW, ImGui, and CMake pitfalls, preserved verbatim from the harness's self-evaluation lessons file. |
+| `INFRASTRUCTURE_REVIEW.md` | Concrete CMake build-reproducibility and Flatpak packaging checklists instantiating the infrastructure-review skill. |
 
 ---
 


### PR DESCRIPTION
Wiring follow-up to the migration imports (#133/#134/#135): makes the repo's own docs and agent guidance reflect what those PRs landed. Paired with story-to-ship PR JPEGtheDev/story-to-ship#62. Merge this PV side first; the s2s side is independent in content but the pair should land in this order for cross-reference stability.

Two commits:

1. `docs: describe committed vs plugin-installed skill sources in AGENTS.md` (638de15) -- AGENTS.md previously claimed all skills/agents are plugin-installed and ".claude/ is NOT in the repo". Since the imports, five paths ARE committed (`.claude/skills/build/`, `.claude/skills/flatpak/`, `.claude/agents/architecture-reviewer.md`, `.claude/agents/infrastructure-reviewer.md`, `.claude/settings.json` -- verified via `git ls-files .claude/`). Three hunks fix the Skills Directory intro, the Agent Prompt Templates intro, and the Source Code Layout comment block to state the dual provisioning (plugin-installed + repo-committed) accurately.

2. `docs: index imported workflow, story, lessons, and infrastructure docs` (ed955c9) -- adds the four missing `docs/INDEX.md` rows for `DEVELOPMENT_WORKFLOW.md`, `STORY_EXAMPLES.md`, `lessons-learned.md`, and `INFRASTRUCTURE_REVIEW.md` (all imported by #133-#135 but never catalogued). After this change every direct `docs/*.md` file has an index row (completeness sweep: 0 missing of 30).

Review pipeline per commit: implementer -> spec-compliance review -> quality review, each with one fix round (count-phrasing nit; two Covers cells trimmed to the table's length rhythm) and a delta re-review APPROVE.

ASCII sweep on both diffs: exit 1 (clean).

Generated with [Claude Code](https://claude.com/claude-code)
